### PR TITLE
fix(release): 显式指定打包工作流 Python 版本

### DIFF
--- a/.github/workflows/release-build-gui.yml
+++ b/.github/workflows/release-build-gui.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version-file: .python-version
+          python-version: '3.13'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -33,7 +33,7 @@ def test_release_build_gui_workflow_builds_windows_gui_and_publishes_release() -
     assert "actions/checkout@v6" in workflow_text
     assert "actions/setup-python@v6" in workflow_text
     assert "astral-sh/setup-uv@v6" in workflow_text
-    assert "python-version-file: .python-version" in workflow_text
+    assert "python-version: '3.13'" in workflow_text
     assert "python scripts/pyinstaller/build_gui.py --clean" in workflow_text
     assert "LolAudioUnpack-$tag-windows-x64.exe" in workflow_text
     assert "softprops/action-gh-release@v2" in workflow_text


### PR DESCRIPTION
## What Changed
- 将 `release-build-gui` workflow 的 Python 设置从 `python-version-file` 改为显式 `python-version: '3.13'`
- 同步更新 workflow 定向测试

## Why
- `v3.6.0-pre.2` 对应 workflow 已经成功命中 tag/main 门禁
- 真实失败点在 `actions/setup-python@v6`，因为 `.python-version` 并未入库，GitHub Actions 运行时无法读取

## Validation
- `uv run pytest -q tests/test_release_workflow.py`
- `uv run ruff check tests/test_release_workflow.py`
- `uv run python -c "from pathlib import Path; from ruamel.yaml import YAML; YAML().load(Path('.github/workflows/release-build-gui.yml').read_text(encoding='utf-8')); print('yaml-ok')"`