### PR TITLE
fix(release): 兼容 Windows 构建日志编码

### DIFF
--- a/scripts/pyinstaller/build_gui.py
+++ b/scripts/pyinstaller/build_gui.py
@@ -27,7 +27,7 @@ def _load_versioning_module():
     module_path = PROJECT_ROOT / "src" / "lol_audio_unpack" / "utils" / "versioning.py"
     spec = importlib.util.spec_from_file_location("lol_audio_unpack_build_versioning", module_path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"无法加载版本模块: {module_path}")
+        raise RuntimeError(f"Failed to load versioning module: {module_path}")
 
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -39,7 +39,7 @@ def _read_static_version() -> str:
     for line in pyproject_path.read_text(encoding="utf-8").splitlines():
         if line.startswith("version = "):
             return line.split("=", 1)[1].strip().strip('"')
-    raise RuntimeError("无法从 pyproject.toml 读取静态版本号")
+    raise RuntimeError("Failed to read static version from pyproject.toml")
 
 
 def _resolve_build_version() -> str:
@@ -122,44 +122,44 @@ def _write_windows_version_file(output_root: Path, *, runtime_version: str) -> P
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="构建 Lol Audio Unpack GUI 的 PyInstaller 包。")
+    parser = argparse.ArgumentParser(description="Build the Lol Audio Unpack GUI package with PyInstaller.")
     parser.add_argument(
         "--mode",
         choices=("onefile", "onedir"),
         default="onefile",
-        help="打包模式，默认使用 onefile。",
+        help="Build mode. Defaults to onefile.",
     )
     parser.add_argument(
         "--output-root",
         default=str(DEFAULT_OUTPUT_ROOT),
-        help="PyInstaller 构建输出根目录，默认写入 .temp/pyinstaller。",
+        help="PyInstaller output root directory. Defaults to .temp/pyinstaller.",
     )
     parser.add_argument(
         "--skip-sync",
         action="store_true",
-        help="跳过 uv sync，只使用当前环境直接构建。",
+        help="Skip uv sync and build with the current environment only.",
     )
     parser.add_argument(
         "--clean",
         action="store_true",
-        help="构建前清理旧的输出目录。",
+        help="Clean previous output directories before building.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="仅打印将要执行的命令，不实际构建。",
+        help="Print commands only without running the actual build.",
     )
     return parser
 
 
 def _ensure_supported_host() -> None:
     if struct.calcsize("P") * 8 != REQUIRED_PYTHON_BITS:
-        raise SystemExit("当前构建脚本仅支持 64 位 Python 运行时。")
+        raise SystemExit("This build script only supports a 64-bit Python runtime.")
 
     machine = platform.machine().lower()
     if machine not in {"amd64", "x86_64"}:
         raise SystemExit(
-            f"当前主机架构为 {platform.machine()}，本构建入口目前仅面向 x64/amd64 本机构建。"
+            f"Unsupported host architecture: {platform.machine()}. Only x64/amd64 hosts are supported."
         )
 
 
@@ -190,7 +190,7 @@ def main() -> int:
     print(f"WorkPath   : {work_path}")
 
     if args.clean and output_root.exists():
-        print(f"清理旧的 PyInstaller 输出目录: {output_root}")
+        print(f"Cleaning previous PyInstaller output directory: {output_root}")
         if not args.dry_run:
             shutil.rmtree(output_root)
 

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -1,5 +1,7 @@
 """PyInstaller 正式构建入口测试。"""
-
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -81,3 +83,28 @@ def test_runtime_hook_uses_runtime_paths_helper() -> None:
     assert "lol_audio_unpack" not in hook_text
     assert "sys.executable" in hook_text
     assert "os.chdir" in hook_text
+
+
+def test_pyinstaller_build_script_dry_run_supports_cp1252_output(tmp_path: Path) -> None:
+    """build script 在 cp1252 控制台下也应能完成 dry-run。"""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PYINSTALLER_DIR / "build_gui.py"),
+            "--dry-run",
+            "--skip-sync",
+            "--clean",
+            "--output-root",
+            str(tmp_path / "pyinstaller-out"),
+        ],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="cp1252",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## What Changed
- 将 `scripts/pyinstaller/build_gui.py` 的控制台输出和异常文案改为 ASCII-safe 文本
- 新增 `cp1252` dry-run 回归测试，覆盖 Windows GitHub Runner 的控制台编码边界

## Why
- `v3.6.0-pre.4` 对应的 release workflow 已经通过 tag/main 门禁和 Python 环境初始化
- 真实失败点在 `Build GUI package`，因为 Windows GitHub Runner 默认 `cp1252` 控制台无法输出脚本中的中文文案，触发 `UnicodeEncodeError`

## Validation
- `uv run ruff check scripts/pyinstaller/build_gui.py tests/test_pyinstaller_packaging.py tests/test_release_workflow.py tests/test_versioning.py`
- `uv run pytest -q tests/test_pyinstaller_packaging.py tests/test_release_workflow.py tests/test_versioning.py`