### PR TITLE
fix(release): 避免 clean 删除版本资源文件

### DIFF
--- a/scripts/pyinstaller/build_gui.py
+++ b/scripts/pyinstaller/build_gui.py
@@ -179,7 +179,6 @@ def main() -> int:
     dist_path = output_root / "dist"
     work_path = output_root / "build"
     runtime_version = _resolve_build_version()
-    version_file = _write_windows_version_file(work_path, runtime_version=runtime_version)
 
     print(f"RepoRoot   : {PROJECT_ROOT}")
     print(f"SpecPath   : {SPEC_PATH}")
@@ -193,6 +192,8 @@ def main() -> int:
         print(f"Cleaning previous PyInstaller output directory: {output_root}")
         if not args.dry_run:
             shutil.rmtree(output_root)
+
+    version_file = _write_windows_version_file(work_path, runtime_version=runtime_version)
 
     if not args.skip_sync:
         _run_command(["uv", "sync", "--extra", "gui", "--group", "build"], dry_run=args.dry_run)

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -1,4 +1,5 @@
 """PyInstaller 正式构建入口测试。"""
+import importlib.util
 import os
 import subprocess
 import sys
@@ -6,6 +7,16 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PYINSTALLER_DIR = PROJECT_ROOT / "scripts" / "pyinstaller"
+
+
+def _load_build_gui_module():
+    module_path = PYINSTALLER_DIR / "build_gui.py"
+    spec = importlib.util.spec_from_file_location("lol_audio_unpack_build_gui_test", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_pyinstaller_entry_files_exist() -> None:
@@ -108,3 +119,29 @@ def test_pyinstaller_build_script_dry_run_supports_cp1252_output(tmp_path: Path)
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_pyinstaller_build_script_keeps_version_file_when_cleaning_output(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """--clean 不应把即将传给 spec 的 version file 一起删掉。"""
+    build_gui = _load_build_gui_module()
+    output_root = tmp_path / "pyinstaller-out"
+    stale_file = output_root / "build" / "stale.txt"
+    stale_file.parent.mkdir(parents=True, exist_ok=True)
+    stale_file.write_text("stale", encoding="utf-8")
+
+    def _fake_run_command(command: list[str], *, dry_run: bool) -> None:
+        assert dry_run is False
+        version_path = Path(command[command.index("--version-file") + 1])
+        assert version_path.is_file()
+        assert "CompanyName" in version_path.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(build_gui, "_ensure_supported_host", lambda: None)
+    monkeypatch.setattr(build_gui, "_resolve_build_version", lambda: "3.6.0-pre.5")
+    monkeypatch.setattr(build_gui, "_run_command", _fake_run_command)
+    monkeypatch.setattr(sys, "argv", ["build_gui.py", "--clean", "--skip-sync", "--output-root", str(output_root)])
+
+    assert build_gui.main() == 0
+    assert stale_file.exists() is False


### PR DESCRIPTION
## What Changed
- 将 Windows version file 的生成时机移动到 `--clean` 之后
- 新增回归测试，确保构建命令执行前传给 spec 的 version file 仍然存在

## Why
- `v3.6.0-pre.5` 对应 workflow 已经越过 tag/main 门禁、Python 初始化、uv 安装和编码问题
- 真实失败点是 `build_gui.py` 先写 version file，再删除输出目录，导致 PyInstaller 读取 version resource 时文件已经不存在

## Validation
- `uv run ruff check scripts/pyinstaller/build_gui.py tests/test_pyinstaller_packaging.py tests/test_release_workflow.py tests/test_versioning.py`
- `uv run pytest -q tests/test_pyinstaller_packaging.py tests/test_release_workflow.py tests/test_versioning.py`