### PR TITLE
fix(release): 补齐 GUI 嵌套资源打包

### DIFF
--- a/scripts/pyinstaller/gui.spec
+++ b/scripts/pyinstaller/gui.spec
@@ -39,8 +39,15 @@ runtime_hooks.append(str(RUNTIME_HOOK))
 
 datas = collect_data_files("qfluentwidgets")
 datas += [
-    (str(path), "lol_audio_unpack/gui/assets")
-    for path in GUI_ASSET_ROOT.iterdir()
+    (
+        str(path),
+        (
+            f"lol_audio_unpack/gui/assets/{path.relative_to(GUI_ASSET_ROOT).parent.as_posix()}"
+            if path.relative_to(GUI_ASSET_ROOT).parent.as_posix() != "."
+            else "lol_audio_unpack/gui/assets"
+        ),
+    )
+    for path in GUI_ASSET_ROOT.rglob("*")
     if path.is_file()
 ]
 

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -50,6 +50,15 @@ def test_pyinstaller_spec_supports_default_onefile_and_optional_onedir() -> None
     assert "exclude_binaries=True" in spec_text
 
 
+def test_pyinstaller_spec_recursively_packages_nested_gui_assets() -> None:
+    """spec 应递归打包 GUI 资源子目录，避免冻结态缺少二维码等嵌套资源。"""
+    spec_text = (PYINSTALLER_DIR / "gui.spec").read_text(encoding="utf-8")
+
+    assert 'GUI_ASSET_ROOT.rglob("*")' in spec_text
+    assert "relative_to(GUI_ASSET_ROOT)" in spec_text
+    assert "lol_audio_unpack/gui/assets/" in spec_text
+
+
 def test_pyinstaller_python_build_script_defaults_to_onefile() -> None:
     """Python 构建入口应默认 onefile，并把模式参数转发给 spec。"""
     script_text = (PYINSTALLER_DIR / "build_gui.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## What
- 修复 `scripts/pyinstaller/gui.spec`，递归收集 GUI 资源并保留子目录结构
- 补充 PyInstaller 打包测试，锁定 `assets/qr/**` 等嵌套资源必须进入构建产物

## Why
- 当前 `v3.6.0` 发布产物启动时缺少 `qr/wechat.png`
- 根因是 GUI 静态资源只打包了 `assets/` 根目录文件，未递归带上 `assets/qr/` 子目录
- 该问题只影响发布打包链路，不需要变更版本号

## Validation
- `uv run pytest -q tests/test_pyinstaller_packaging.py tests/test_release_workflow.py tests/gui/test_resource_catalog.py`
- `uv run python scripts/pyinstaller/build_gui.py --mode onedir --clean`
- `uv run python scripts/pyinstaller/build_gui.py --clean`
- 本地启动 onedir 与 onefile 构建产物，5 秒内均未复现启动即崩