### PR TITLE
feat(gui): 增加试听音频右键导出

### DIFF
--- a/src/lol_audio_unpack/gui/components/preview_tree.py
+++ b/src/lol_audio_unpack/gui/components/preview_tree.py
@@ -449,7 +449,9 @@ def extract_preview_modifiers(mapping_data: dict[str, Any] | None) -> PreviewMod
             prefixes.add(parts[0])
             suffixes.add(parts[-1])
 
-    sort_key = lambda value: value.casefold()
+    def sort_key(value: str) -> str:
+        return value.casefold()
+
     return PreviewModifierSummary(
         prefixes=tuple(sorted(prefixes, key=sort_key)),
         suffixes=tuple(sorted(suffixes, key=sort_key)),
@@ -790,6 +792,7 @@ class PreviewTreeView(QTreeView):
     """最基础的试听树视图。"""
 
     audio_id_toggle_requested = Signal(str)
+    audio_context_menu_requested = Signal(str, QPoint)
 
     def _index_depth(self, index: QModelIndex) -> int:
         """返回当前节点深度。"""
@@ -978,6 +981,15 @@ class PreviewTreeView(QTreeView):
         model = self.model()
         return bool(index.isValid() and model is not None and model.data(index, AUDIO_AVAILABLE_ROLE))
 
+    def _context_audio_id_at(self, pos: QPoint) -> str | None:
+        """解析右键位置命中的可用音频 ID。"""
+        index = self.indexAt(pos)
+        if not index.isValid():
+            return None
+        if not self._is_audio_leaf(index) or not self._is_audio_available(index):
+            return None
+        return self._audio_id_for_index(index)
+
     def _playback_progress_for_index(self, index: QModelIndex) -> float:
         """返回当前行的试听进度。"""
         if self._audio_id_for_index(index) != self._active_audio_id:
@@ -1101,6 +1113,15 @@ class PreviewTreeView(QTreeView):
                 event.accept()
                 return
         super().mouseReleaseEvent(event)
+
+    def contextMenuEvent(self, event) -> None:
+        """只在右键命中可试听音频叶子项时请求页面展示菜单。"""
+        audio_id = self._context_audio_id_at(event.pos())
+        if audio_id is None:
+            event.ignore()
+            return
+        self.audio_context_menu_requested.emit(audio_id, event.globalPos())
+        event.accept()
 
     def drawBranches(self, painter: QPainter, rect: QRect, index: QModelIndex) -> None:
         """只绘制展开/收缩图标，避免默认 branch 连接线与背景叠加。"""

--- a/src/lol_audio_unpack/gui/service/preview_export.py
+++ b/src/lol_audio_unpack/gui/service/preview_export.py
@@ -1,0 +1,62 @@
+"""试听音频单文件 WAV 导出服务。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from pyvgmstream import decode_to_wav_file
+
+from lol_audio_unpack.runtime.wav import build_output_path, resolve_decode_config
+
+
+def resolve_wav_path(
+    wem_path: str | Path,
+    *,
+    audio_root: str | Path,
+    wav_root: str | Path,
+) -> Path:
+    """按正式 WAV 输出镜像规则推导试听音频的默认 WAV 路径。
+
+    Args:
+        wem_path: 当前试听音频的 ``.wem`` 路径。
+        audio_root: 当前版本 ``audios/<version>`` 根目录。
+        wav_root: 当前版本 ``wavs/<version>`` 根目录。
+
+    Returns:
+        默认镜像 ``.wav`` 路径。
+    """
+    return build_output_path(
+        Path(wem_path),
+        audio_root=Path(audio_root),
+        wav_root=Path(wav_root),
+    )
+
+
+def transcode_wav(
+    wem_path: str | Path,
+    wav_path: str | Path,
+    *,
+    wav_format: str = "pcm16",
+    decode_fn: Callable[..., Any] = decode_to_wav_file,
+) -> Path:
+    """把单个试听 ``.wem`` 转码为 ``.wav``。
+
+    Args:
+        wem_path: 输入 ``.wem`` 路径。
+        wav_path: 输出 ``.wav`` 路径。
+        wav_format: WAV 输出格式，沿用现有 ``auto/pcm16/pcm24/pcm32/float`` 语义。
+        decode_fn: 解码函数，供测试替换。
+
+    Returns:
+        实际写出的 ``.wav`` 路径。
+    """
+    output = Path(wav_path).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    result = decode_fn(
+        Path(wem_path).expanduser().resolve(),
+        output,
+        config=resolve_decode_config(wav_format),
+    )
+    return Path(getattr(result, "output_path", output))

--- a/src/lol_audio_unpack/gui/view/overview_page.py
+++ b/src/lol_audio_unpack/gui/view/overview_page.py
@@ -11,6 +11,7 @@ from loguru import logger
 from PySide6.QtCore import (
     QItemSelectionModel,
     QModelIndex,
+    QPoint,
     QSignalBlocker,
     Qt,
     QUrl,
@@ -18,6 +19,7 @@ from PySide6.QtCore import (
 )
 from PySide6.QtGui import QDesktopServices, QTextOption
 from PySide6.QtWidgets import (
+    QFileDialog,
     QFrame,
     QHBoxLayout,
     QPlainTextEdit,
@@ -28,14 +30,17 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 from qfluentwidgets import (
+    Action,
     BodyLabel,
     CaptionLabel,
     InfoBar,
     InfoBarPosition,
     LineEdit,
+    MenuAnimationType,
     PlainTextEdit,
     PrimaryPushButton,
     PushButton,
+    RoundMenu,
     SearchLineEdit,
     SegmentedWidget,
     StrongBodyLabel,
@@ -69,6 +74,7 @@ from lol_audio_unpack.gui.controllers.entity_data_store import EntityDataStore
 from lol_audio_unpack.gui.controllers.overview_preview import AudioPreviewToggleResult
 from lol_audio_unpack.gui.controllers.preview_playback import PreviewPlaybackState
 from lol_audio_unpack.gui.service.data_loader import EntityDataLoader
+from lol_audio_unpack.gui.service.preview_export import resolve_wav_path, transcode_wav
 from lol_audio_unpack.gui.view.overview.audio_preview_panel import OverviewAudioPreviewPanel
 from lol_audio_unpack.gui.view.overview.entity_list_panel import OverviewEntityListPanel
 from lol_audio_unpack.gui.view.overview.preview_panel import (
@@ -251,6 +257,7 @@ class OverviewPage(QWidget):
         self.clear_selection_btn.clicked.connect(self._clear_selected_entities)
         self.reveal_file_btn.clicked.connect(self._reveal_selected_mapping_file)
         self.audio_preview_tree.audio_id_toggle_requested.connect(self._on_audio_preview_toggle_requested)
+        self.audio_preview_tree.audio_context_menu_requested.connect(self._show_audio_menu)
         qconfig.themeChanged.connect(self._refresh_theme_styles)
         qconfig.themeColorChanged.connect(self._refresh_entity_list_theme)
 
@@ -568,6 +575,121 @@ class OverviewPage(QWidget):
             audio_path=result.audio_path,
         )
 
+    def _audio_menu_wem_path(self, audio_id: str) -> Path | None:
+        """解析右键菜单目标音频的 WEM 路径。"""
+        loader = self._ensure_loader()
+        if (
+            loader is None
+            or self._current_preview_entity_type is None
+            or self._current_preview_entity_id is None
+        ):
+            return None
+        return loader.resolve_audio_file_path(
+            self._current_preview_entity_type,
+            self._current_preview_entity_id,
+            audio_id,
+        )
+
+    def _show_audio_menu(self, audio_id: str, global_pos: QPoint) -> None:
+        """显示试听音频叶子项右键菜单。"""
+        wem_path = self._audio_menu_wem_path(audio_id)
+        if wem_path is None:
+            return
+
+        menu = RoundMenu(parent=self.audio_preview_tree)
+
+        save_action = Action("另存为 WAV...", menu)
+        save_action.triggered.connect(lambda: self._save_audio_wav(audio_id, wem_path))
+        menu.addAction(save_action)
+
+        reveal_wem_action = Action("打开 WEM 所在位置", menu)
+        reveal_wem_action.triggered.connect(lambda: self._reveal_wem(wem_path))
+        menu.addAction(reveal_wem_action)
+
+        reveal_wav_action = Action("转码并打开 WAV 所在位置", menu)
+        reveal_wav_action.triggered.connect(lambda: self._reveal_wav(wem_path))
+        menu.addAction(reveal_wav_action)
+
+        menu.exec(global_pos, aniType=MenuAnimationType.DROP_DOWN)
+
+    def _wav_format(self) -> str:
+        """返回右键单文件转码使用的 WAV 格式。"""
+        return str(getattr(self.gui_config, "wav_format", "pcm16") or "pcm16")
+
+    def _save_audio_wav(self, audio_id: str, wem_path: Path) -> None:
+        """把当前试听音频另存为用户选择的 WAV 文件。"""
+        output_text, _selected_filter = QFileDialog.getSaveFileName(
+            self,
+            "另存为 WAV",
+            f"{audio_id}.wav",
+            "WAV 音频 (*.wav);;所有文件 (*)",
+        )
+        if not output_text:
+            return
+
+        output = Path(output_text)
+        if output.suffix.lower() != ".wav":
+            output = output.with_suffix(".wav")
+
+        try:
+            transcode_wav(wem_path, output, wav_format=self._wav_format())
+        except Exception as exc:  # noqa: BLE001
+            InfoBar.warning(
+                "另存 WAV 失败",
+                f"{type(exc).__name__}: {exc}",
+                parent=self.window(),
+                position=InfoBarPosition.TOP,
+            )
+            return
+
+        InfoBar.success(
+            "已保存 WAV",
+            str(output),
+            parent=self.window(),
+            position=InfoBarPosition.TOP,
+        )
+
+    def _reveal_wem(self, wem_path: Path) -> None:
+        """打开当前试听 WEM 所在位置。"""
+        if self._reveal_file_path(wem_path):
+            return
+        InfoBar.warning(
+            "打开目录失败",
+            f"无法打开目录：{wem_path.parent}",
+            parent=self.window(),
+            position=InfoBarPosition.TOP,
+        )
+
+    def _reveal_wav(self, wem_path: Path) -> None:
+        """转码当前试听音频到默认 WAV 镜像路径并定位文件。"""
+        loader = self._ensure_loader()
+        if self._app_context is None or loader is None:
+            return
+
+        version = loader.data_reader.version
+        audio_root = Path(self._app_context.paths.audio_path) / version
+        wav_root = Path(self._app_context.paths.wav_path) / version
+        try:
+            wav_path = resolve_wav_path(wem_path, audio_root=audio_root, wav_root=wav_root)
+            if not wav_path.exists():
+                transcode_wav(wem_path, wav_path, wav_format=self._wav_format())
+        except Exception as exc:  # noqa: BLE001
+            InfoBar.warning(
+                "转码 WAV 失败",
+                f"{type(exc).__name__}: {exc}",
+                parent=self.window(),
+                position=InfoBarPosition.TOP,
+            )
+            return
+
+        if not self._reveal_file_path(wav_path):
+            InfoBar.warning(
+                "打开目录失败",
+                f"无法打开目录：{wav_path.parent}",
+                parent=self.window(),
+                position=InfoBarPosition.TOP,
+            )
+
     def _apply_audio_preview_playback_state(self, state: PreviewPlaybackState) -> None:
         """同步播放控制器发出的最新试听状态。"""
         self._current_audio_preview_audio_id = state.audio_id
@@ -660,23 +782,28 @@ class OverviewPage(QWidget):
             return
 
         target_path = self._current_mapping_path
-        directory = target_path.parent
+        if self._reveal_file_path(target_path):
+            return
 
+        directory = target_path.parent
+        InfoBar.warning(
+            "打开目录失败",
+            f"无法打开目录：{directory}",
+            parent=self.window(),
+            position=InfoBarPosition.TOP,
+        )
+
+    def _reveal_file_path(self, target_path: Path) -> bool:
+        """在系统文件管理器中定位指定文件。"""
+        directory = target_path.parent
         try:
             if os.name == "nt" and target_path.exists():
                 subprocess.Popen(["explorer.exe", "/select,", str(target_path)])
-                return
+                return True
         except OSError:
             pass
 
-        opened = QDesktopServices.openUrl(QUrl.fromLocalFile(str(directory)))
-        if not opened:
-            InfoBar.warning(
-                "打开目录失败",
-                f"无法打开目录：{directory}",
-                parent=self.window(),
-                position=InfoBarPosition.TOP,
-            )
+        return QDesktopServices.openUrl(QUrl.fromLocalFile(str(directory)))
 
     def set_smooth_scroll_enabled(self, enabled: bool) -> None:
         """根据设置应用总览页的滚动模式。"""

--- a/tests/gui/test_overview_page_playback.py
+++ b/tests/gui/test_overview_page_playback.py
@@ -12,6 +12,8 @@ from lol_audio_unpack.gui.controllers.overview_preview import (
 )
 from lol_audio_unpack.gui.view.overview_page import OverviewPage
 
+MAP_PREVIEW_ENTITY_ID = 12
+
 
 def test_overview_page_preview_audio_settings_forward_to_playback_controller(qtbot) -> None:
     page = OverviewPage()
@@ -159,7 +161,7 @@ def test_overview_page_logs_preview_modifiers_after_loading_preview(qtbot) -> No
     )
     page._preview_controller = SimpleNamespace(
         load_preview=lambda **_kwargs: OverviewPreviewLoadResult(
-            entity_id="12",
+            entity_id=str(MAP_PREVIEW_ENTITY_ID),
             mapping_path=Path("preview.msgpack"),
             mapping_data={
                 "map": {
@@ -192,7 +194,60 @@ def test_overview_page_logs_preview_modifiers_after_loading_preview(qtbot) -> No
     template, entity_type, entity_id, prefixes, suffixes, audio_types = records[0]
     assert template.startswith("[总览预览]")
     assert entity_type == "maps"
-    assert entity_id == 12
+    assert entity_id == MAP_PREVIEW_ENTITY_ID
     assert prefixes == ["ENV", "MUS", "NPC"]
     assert suffixes == ["FirstBlood", "SFX", "VO"]
     assert audio_types == ["ENV_Map12_SFX", "MUS_Map12_FirstBlood", "NPC_Map12_VO"]
+
+
+def test_overview_page_audio_menu_resolves_wem_without_toggling_playback(qtbot) -> None:
+    page = OverviewPage()
+    qtbot.addWidget(page)
+    stopped: list[bool] = []
+    page._preview_playback_controller = SimpleNamespace(
+        set_volume_percent=lambda _value: None,
+        set_output_device_key=lambda _value: None,
+        play=lambda **_kwargs: None,
+        stop=lambda: stopped.append(True),
+    )
+    page._loader = SimpleNamespace(
+        resolve_audio_file_path=lambda entity_type, entity_id, audio_id: Path("1001.wem"),
+    )
+    page._current_preview_entity_type = "champions"
+    page._current_preview_entity_id = "1"
+
+    result = page._audio_menu_wem_path("1001")
+
+    assert result == Path("1001.wem")
+    assert stopped == []
+
+
+def test_overview_page_reveal_wav_reuses_existing_file(qtbot, tmp_path, monkeypatch) -> None:
+    page = OverviewPage()
+    qtbot.addWidget(page)
+    wem_path = tmp_path / "audios" / "15.10" / "champions" / "1" / "VO" / "1001.wem"
+    wav_path = tmp_path / "wavs" / "15.10" / "champions" / "1" / "VO" / "1001.wav"
+    wav_path.parent.mkdir(parents=True)
+    wav_path.write_bytes(b"RIFF....WAVE")
+    page._app_context = SimpleNamespace(
+        paths=SimpleNamespace(
+            audio_path=tmp_path / "audios",
+            wav_path=tmp_path / "wavs",
+        )
+    )
+    page._loader = SimpleNamespace(data_reader=SimpleNamespace(version="15.10"))
+    opened: list[Path] = []
+    transcoded: list[tuple[Path, Path]] = []
+
+    monkeypatch.setattr(page, "_reveal_file_path", lambda path: opened.append(Path(path)) or True)
+    monkeypatch.setattr(
+        overview_page_module,
+        "transcode_wav",
+        lambda source, target, *, wav_format: transcoded.append((Path(source), Path(target))) or Path(target),
+        raising=False,
+    )
+
+    page._reveal_wav(wem_path)
+
+    assert opened == [wav_path]
+    assert transcoded == []

--- a/tests/gui/test_preview_export.py
+++ b/tests/gui/test_preview_export.py
@@ -1,0 +1,37 @@
+"""试听音频右键导出服务测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from lol_audio_unpack.gui.service.preview_export import resolve_wav_path, transcode_wav
+
+
+def test_resolve_wav_path_mirrors_audio_tree(tmp_path: Path) -> None:
+    audio_root = tmp_path / "audios" / "15.10"
+    wav_root = tmp_path / "wavs" / "15.10"
+    wem_path = audio_root / "champions" / "1" / "VO" / "1001.wem"
+
+    result = resolve_wav_path(wem_path, audio_root=audio_root, wav_root=wav_root)
+
+    assert result == wav_root / "champions" / "1" / "VO" / "1001.wav"
+
+
+def test_transcode_wav_uses_requested_format(tmp_path: Path) -> None:
+    wem_path = tmp_path / "1001.wem"
+    wav_path = tmp_path / "1001.wav"
+    calls: list[tuple[Path, Path, object]] = []
+
+    def fake_decode(in_path, out_path, *, config):
+        calls.append((Path(in_path), Path(out_path), config))
+        Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(out_path).write_bytes(b"RIFF....WAVE")
+        return SimpleNamespace(output_path=Path(out_path))
+
+    result = transcode_wav(wem_path, wav_path, wav_format="pcm16", decode_fn=fake_decode)
+
+    assert result == wav_path.resolve()
+    assert calls[0][0] == wem_path.resolve()
+    assert calls[0][1] == wav_path.resolve()
+    assert getattr(calls[0][2], "sample_format", None) is not None

--- a/tests/gui/test_preview_tree_control_icon.py
+++ b/tests/gui/test_preview_tree_control_icon.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 
-from PySide6.QtCore import QRect
+from PySide6.QtCore import QModelIndex, QPoint, QRect
 from qfluentwidgets import qconfig
 
 from lol_audio_unpack.gui.components.preview_tree import (
@@ -63,3 +63,28 @@ def test_preview_tree_accent_helpers_use_preset_tones_in_light_mode() -> None:
         assert progress_color == expected_progress
         assert button_background == expected_button
         assert icon_color == expected_icon
+
+
+def test_preview_tree_context_audio_id_requires_valid_index(qtbot, monkeypatch) -> None:
+    view = PreviewTreeView()
+    qtbot.addWidget(view)
+    monkeypatch.setattr(view, "indexAt", lambda _pos: QModelIndex(), raising=False)
+
+    assert view._context_audio_id_at(QPoint(12, 12)) is None
+
+
+def test_preview_tree_context_audio_id_returns_available_audio_id(qtbot, monkeypatch) -> None:
+    view = PreviewTreeView()
+    qtbot.addWidget(view)
+
+    class _FakeIndex:
+        def isValid(self) -> bool:
+            return True
+
+    index = _FakeIndex()
+    monkeypatch.setattr(view, "indexAt", lambda _pos: index, raising=False)
+    monkeypatch.setattr(view, "_is_audio_leaf", lambda item: item is index, raising=False)
+    monkeypatch.setattr(view, "_is_audio_available", lambda item: item is index, raising=False)
+    monkeypatch.setattr(view, "_audio_id_for_index", lambda item: "1001" if item is index else None, raising=False)
+
+    assert view._context_audio_id_at(QPoint(12, 12)) == "1001"


### PR DESCRIPTION
## Why
- 试听列表需要少量音频的快速另存和定位能力。
- 该能力使用频率低，现阶段不值得为避免一次额外转码改造播放缓存。

## What
- 在可用音频叶子项上增加右键菜单。
- 支持另存为 WAV、打开 WEM 所在位置、转码并打开默认 WAV 所在位置。
- 新增单文件 WAV 路径推导和转码服务。
- 补充右键命中、导出服务和页面编排测试。

## Risk
- 左键试听链路保持不变。
- 真实 GUI 文件管理器交互仍需人工验收。

## Test
- uv run pytest -q tests/gui/test_preview_export.py tests/gui/test_preview_tree_control_icon.py tests/gui/test_overview_page_playback.py tests/gui/test_overview_preview_controller.py -> 19 passed
- uv run ruff check src/lol_audio_unpack/gui/components/preview_tree.py src/lol_audio_unpack/gui/view/overview_page.py src/lol_audio_unpack/gui/service/preview_export.py tests/gui/test_preview_export.py tests/gui/test_preview_tree_control_icon.py tests/gui/test_overview_page_playback.py -> All checks passed!
- git diff --check origin/v3-test..HEAD -> 无输出