### PR TITLE
feat(gui): 增加新手引导流程

### DIFF
--- a/src/lol_audio_unpack/gui/common/gui_config.py
+++ b/src/lol_audio_unpack/gui/common/gui_config.py
@@ -36,6 +36,8 @@ from lol_audio_unpack.utils.runtime_paths import (
 # ---------------------------------------------------------------------------
 
 _UNSET = object()  # distinguishes "not in file" from ""
+_ONBOARDING_COMPLETED_KEY = "onboarding/completed_version"
+_ONBOARDING_SKIPPED_KEY = "onboarding/skipped_version"
 
 
 class GuiConfig:
@@ -298,6 +300,61 @@ class GuiConfig:
     def resolve_vgmstream_path(self) -> Path | None:
         """解析当前 GUI 配置对应的有效 vgmstream 工具路径。"""
         return self._resolve_optional_runtime_path(self._vgmstream_path)
+
+    def should_show_onboarding(self, guide_version: str) -> bool:
+        """返回当前引导版本是否应该自动展示。
+
+        Args:
+            guide_version: 当前引导内容版本。
+
+        Returns:
+            bool: 当前版本既未完成也未跳过时返回 ``True``。
+        """
+
+        version = str(guide_version or "").strip()
+        if not version:
+            return False
+        completed = str(self._qs.value(_ONBOARDING_COMPLETED_KEY, "") or "")
+        skipped = str(self._qs.value(_ONBOARDING_SKIPPED_KEY, "") or "")
+        return version not in (completed, skipped)
+
+    def mark_onboarding_completed(self, guide_version: str) -> None:
+        """记录当前引导版本已经完成。
+
+        Args:
+            guide_version: 当前引导内容版本。
+        """
+
+        version = str(guide_version or "").strip()
+        if version:
+            self._qs.setValue(_ONBOARDING_COMPLETED_KEY, version)
+
+    def mark_onboarding_skipped(self, guide_version: str) -> None:
+        """记录当前引导版本已经跳过。
+
+        Args:
+            guide_version: 当前引导内容版本。
+        """
+
+        version = str(guide_version or "").strip()
+        if version:
+            self._qs.setValue(_ONBOARDING_SKIPPED_KEY, version)
+
+    def reset_onboarding(self, guide_version: str) -> None:
+        """清除当前引导版本的完成与跳过状态。
+
+        Args:
+            guide_version: 当前引导内容版本。
+        """
+
+        version = str(guide_version or "").strip()
+        if not version:
+            return
+
+        if str(self._qs.value(_ONBOARDING_COMPLETED_KEY, "") or "") == version:
+            self._qs.setValue(_ONBOARDING_COMPLETED_KEY, "")
+        if str(self._qs.value(_ONBOARDING_SKIPPED_KEY, "") or "") == version:
+            self._qs.setValue(_ONBOARDING_SKIPPED_KEY, "")
 
     # ------------------------------------------------------------------
     # Properties — source

--- a/src/lol_audio_unpack/gui/controllers/game_path_resolver.py
+++ b/src/lol_audio_unpack/gui/controllers/game_path_resolver.py
@@ -1,0 +1,186 @@
+"""GUI 游戏目录识别与归一化。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from lol_audio_unpack.app.game_version import get_game_version
+
+GamePathResultReason = Literal["resolved", "not_found", "ambiguous"]
+
+_MAX_ANCESTORS = 8
+_MAX_SHALLOW_CHILDREN = 80
+_FIXED_SUFFIXES = (
+    ("game",),
+    ("leagueclient",),
+    ("leagueclient", "plugins", "rcp-be-lol-game-data"),
+    ("game", "data", "final", "champions"),
+    ("game", "data", "final", "maps", "shipping"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PathProbe:
+    """单个候选游戏根目录的识别结果。"""
+
+    root: Path
+    version: str | None
+    markers: tuple[str, ...]
+    score: int
+
+
+@dataclass(frozen=True, slots=True)
+class PathProbeResult:
+    """用户输入路径的游戏目录识别结果。"""
+
+    input_path: Path
+    root: Path | None
+    version: str | None
+    candidates: tuple[PathProbe, ...]
+    reason: GamePathResultReason
+
+    @property
+    def resolved(self) -> bool:
+        """返回是否已经唯一识别到游戏根目录。"""
+
+        return self.reason == "resolved" and self.root is not None
+
+
+def resolve_game_path(input_path: str | Path) -> PathProbeResult:
+    """从用户选择的位置识别并归一化英雄联盟客户端根目录。
+
+    Args:
+        input_path: 用户选择或输入的游戏安装相关路径。
+
+    Returns:
+        PathProbeResult: 识别结果。只有唯一强匹配时才返回 resolved。
+    """
+
+    raw = Path(input_path).expanduser()
+    probes = tuple(
+        probe
+        for candidate in _candidate_roots(raw)
+        if (probe := _probe_root(candidate.resolve(strict=False))) is not None
+    )
+
+    if len(probes) == 1:
+        probe = probes[0]
+        return PathProbeResult(
+            input_path=raw,
+            root=probe.root,
+            version=probe.version,
+            candidates=probes,
+            reason="resolved",
+        )
+
+    if len(probes) > 1:
+        return PathProbeResult(
+            input_path=raw,
+            root=None,
+            version=None,
+            candidates=probes,
+            reason="ambiguous",
+        )
+
+    return PathProbeResult(input_path=raw, root=None, version=None, candidates=(), reason="not_found")
+
+
+def _candidate_roots(input_path: Path) -> tuple[Path, ...]:
+    """生成有限数量的候选客户端根目录。"""
+
+    start = input_path.parent if input_path.is_file() else input_path
+    candidates: list[Path] = []
+
+    _append_unique(candidates, start)
+    for root in _roots_from_fixed_suffix(start):
+        _append_unique(candidates, root)
+
+    current = start
+    for _index in range(_MAX_ANCESTORS):
+        parent = current.parent
+        if parent == current:
+            break
+        _append_unique(candidates, parent)
+        for root in _roots_from_fixed_suffix(parent):
+            _append_unique(candidates, root)
+        current = parent
+
+    for child in _shallow_children(start):
+        _append_unique(candidates, child)
+
+    return tuple(candidates)
+
+
+def _probe_root(root: Path) -> PathProbe | None:
+    """检查候选根目录是否符合现行 LCU/WAD 安装结构。"""
+
+    try:
+        version = get_game_version(root)
+    except (OSError, KeyError, TypeError, ValueError):
+        return None
+
+    score, markers = _marker_score(root)
+    return PathProbe(root=root, version=version, markers=markers, score=score)
+
+
+def _marker_score(root: Path) -> tuple[int, tuple[str, ...]]:
+    """统计候选根目录的佐证标志。"""
+
+    checks = (
+        ("content-metadata", root / "Game" / "content-metadata.json"),
+        ("game-binary", root / "Game" / "League of Legends.exe"),
+        ("lcu-binary", root / "LeagueClient" / "LeagueClient.exe"),
+        ("lcu-game-data", root / "LeagueClient" / "Plugins" / "rcp-be-lol-game-data"),
+        ("champions-data", root / "Game" / "DATA" / "FINAL" / "Champions"),
+        ("maps-data", root / "Game" / "DATA" / "FINAL" / "Maps" / "Shipping"),
+    )
+    markers = tuple(name for name, path in checks if path.exists())
+    return 100 + len(markers), markers
+
+
+def _roots_from_fixed_suffix(path: Path) -> tuple[Path, ...]:
+    """根据固定目录后缀反推出可能的客户端根目录。"""
+
+    parts = tuple(part.lower() for part in path.parts)
+    roots: list[Path] = []
+    for suffix in _FIXED_SUFFIXES:
+        if len(parts) >= len(suffix) and parts[-len(suffix) :] == suffix:
+            _append_unique(roots, path.parents[len(suffix) - 1])
+    return tuple(roots)
+
+
+def _shallow_children(path: Path) -> tuple[Path, ...]:
+    """生成一层子目录候选，避免递归扫描整盘。"""
+
+    if not path.is_dir():
+        return ()
+
+    roots: list[Path] = []
+    try:
+        children = [child for child in path.iterdir() if child.is_dir()]
+    except OSError:
+        return ()
+
+    for child in children[:_MAX_SHALLOW_CHILDREN]:
+        if (child / "Game").exists() or (child / "LeagueClient").exists():
+            _append_unique(roots, child)
+
+    return tuple(roots)
+
+
+def _append_unique(paths: list[Path], path: Path) -> None:
+    """按解析后的路径去重并保留首次出现顺序。"""
+
+    resolved = path.resolve(strict=False)
+    if resolved not in {item.resolve(strict=False) for item in paths}:
+        paths.append(resolved)
+
+
+__all__ = [
+    "GamePathResultReason",
+    "PathProbe",
+    "PathProbeResult",
+    "resolve_game_path",
+]

--- a/src/lol_audio_unpack/gui/controllers/onboarding.py
+++ b/src/lol_audio_unpack/gui/controllers/onboarding.py
@@ -1,0 +1,507 @@
+"""GUI 新手引导控制器。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from PySide6.QtCore import QEvent, QPoint, QRect, QRectF, Qt, QTimer
+from PySide6.QtGui import QBitmap, QColor, QPainter, QPainterPath, QPaintEvent, QRegion
+from PySide6.QtWidgets import QHBoxLayout, QWidget
+from qfluentwidgets import PrimaryPushButton, PushButton, TeachingTip, TeachingTipTailPosition, TeachingTipView
+
+from lol_audio_unpack.gui.controllers.onboarding_state import GUIDE_VERSION
+
+_NORMAL_STEP_DELAY_MS = 120
+_NAV_STEP_DELAY_MS = 80
+_ROUTE_SETTLE_DELAY_MS = 420
+_MASK_RESYNC_DELAYS_MS = (0, 120, 320)
+_MASK_HOLE_RADIUS = 8
+
+
+@dataclass(frozen=True, slots=True)
+class TourStep:
+    """单个新手引导步骤。"""
+
+    key: str
+    page_name: str
+    target: Callable[[], QWidget | None]
+    title: str
+    content: str
+    tail_position: TeachingTipTailPosition = TeachingTipTailPosition.BOTTOM
+    allow_next: bool = True
+    wait_for_page_name: str | None = None
+
+
+class OnboardingMask(QWidget):
+    """新手引导期间阻断非目标区域点击的蒙版。"""
+
+    def __init__(self, host: QWidget, *, padding: int = 8, radius: int = _MASK_HOLE_RADIUS) -> None:
+        """创建覆盖主窗口的引导蒙版。
+
+        Args:
+            host: 蒙版覆盖的宿主窗口。
+            padding: 目标控件周围保留的透明边距。
+            radius: 目标透明区域的圆角半径。
+        """
+
+        super().__init__(host)
+        self._host = host
+        self._target: QWidget | None = None
+        self._padding = padding
+        self._radius = radius
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, False)
+        self.setWindowFlags(Qt.WindowType.Widget)
+        self.setGeometry(host.rect())
+        host.installEventFilter(self)
+
+    def set_target(self, target: QWidget) -> None:
+        """设置当前高亮目标控件。"""
+
+        self._target = target
+        self.sync()
+
+    def sync(self) -> None:
+        """同步宿主窗口尺寸和透明目标区域。"""
+
+        self.setGeometry(self._host.rect())
+        hole = self._target_rect()
+        self.setMask(self._mask_region(hole))
+        self.update()
+
+    def eventFilter(self, watched, event) -> bool:
+        """宿主窗口变化时刷新蒙版区域。"""
+
+        if watched is self._host and event.type() in {
+            QEvent.Type.Resize,
+            QEvent.Type.Move,
+            QEvent.Type.WindowStateChange,
+        }:
+            QTimer.singleShot(0, self.sync)
+        return super().eventFilter(watched, event)
+
+    def closeEvent(self, event) -> None:
+        """关闭时解除宿主事件过滤。"""
+
+        self._host.removeEventFilter(self)
+        super().closeEvent(event)
+
+    def paintEvent(self, event: QPaintEvent) -> None:
+        """绘制半透明遮罩。"""
+
+        painter = QPainter(self)
+        painter.fillRect(event.rect(), QColor(0, 0, 0, 135))
+
+    def _target_rect(self) -> QRect:
+        """返回目标控件在宿主窗口坐标系中的透明区域。"""
+
+        if self._target is None or not self._target.isVisible():
+            return QRect()
+        pos = self._target.mapTo(self._host, QPoint(0, 0))
+        return QRect(pos, self._target.size()).adjusted(
+            -self._padding,
+            -self._padding,
+            self._padding,
+            self._padding,
+        ).intersected(self.rect())
+
+    def _mask_region(self, hole: QRect) -> QRegion:
+        """返回扣除目标圆角透明区域后的蒙版命中区域。"""
+
+        if hole.isNull():
+            return QRegion(self.rect())
+
+        bitmap = QBitmap(self.size())
+        bitmap.fill(Qt.GlobalColor.color1)
+
+        radius = min(self._radius, hole.width() // 2, hole.height() // 2)
+        path = QPainterPath()
+        path.addRoundedRect(QRectF(hole), radius, radius)
+
+        painter = QPainter(bitmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(Qt.GlobalColor.color0)
+        painter.drawPath(path)
+        painter.end()
+
+        return QRegion(bitmap)
+
+
+class OnboardingTourController:
+    """管理首次引导的步骤、跳转、气泡与持久化状态。"""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        window,
+        config,
+        setting_page,
+        execution_page,
+        overview_page,
+        has_active_work: Callable[[], bool],
+    ) -> None:
+        """创建新手引导控制器。
+
+        Args:
+            window: 主窗口对象，需要提供 ``switchTo``。
+            config: GUI 配置对象，需要提供引导状态方法。
+            setting_page: 设置页实例。
+            execution_page: 执行中心实例。
+            overview_page: 实体总览实例。
+            has_active_work: 判断是否存在后台任务的回调。
+        """
+
+        self._window = window
+        self._config = config
+        self._setting_page = setting_page
+        self._execution_page = execution_page
+        self._overview_page = overview_page
+        self._has_active_work = has_active_work
+        self._steps = self._build_steps()
+        self._index = 0
+        self._tip: QWidget | None = None
+        self._mask: OnboardingMask | None = None
+        self._running = False
+        self._route_settle_pending = False
+        current_changed = getattr(getattr(window, "stackedWidget", None), "currentChanged", None)
+        if current_changed is not None:
+            current_changed.connect(self._on_current_page_changed)
+
+    def start_if_needed(self) -> None:
+        """满足首次展示条件时启动引导。"""
+
+        if not self._config.should_show_onboarding(GUIDE_VERSION):
+            return
+        if self._has_active_work():
+            return
+        self.start()
+
+    def start(self) -> None:
+        """从第一步开始展示引导。"""
+
+        self._running = True
+        self._index = 0
+        self._show_current()
+
+    def close(self) -> None:
+        """关闭当前气泡并释放引用。"""
+
+        self._running = False
+        self._close_tip()
+        self._close_mask()
+
+    def _next(self) -> None:
+        """进入下一步。"""
+
+        if self._index >= len(self._steps) - 1:
+            self._finish()
+            return
+        self._index += 1
+        self._show_current()
+
+    def _skip(self) -> None:
+        """跳过当前引导版本。"""
+
+        self._config.mark_onboarding_skipped(GUIDE_VERSION)
+        self.close()
+
+    def _finish(self) -> None:
+        """完成当前引导版本。"""
+
+        self._config.mark_onboarding_completed(GUIDE_VERSION)
+        self.close()
+
+    def _show_current(self) -> None:
+        """切换页面并延迟展示当前步骤。"""
+
+        self._close_tip()
+        self._close_mask()
+        if not self._running:
+            return
+        if self._index >= len(self._steps):
+            return
+
+        step = self._steps[self._index]
+        self._switch_to_step_page(step)
+        QTimer.singleShot(self._step_delay(step), lambda: self._show_step(step))
+
+    def _show_step(self, step: TourStep) -> None:
+        """展示指定步骤；目标不可用时跳过到下一步。"""
+
+        if not self._running or self._index >= len(self._steps) or self._steps[self._index] is not step:
+            return
+
+        target = step.target()
+        if target is None or not target.isVisible():
+            self._index += 1
+            self._show_current()
+            return
+
+        self._ensure_visible(step, target)
+        self._show_mask(target)
+        view = TeachingTipView(
+            title=step.title,
+            content=step.content,
+            isClosable=False,
+            tailPosition=step.tail_position,
+        )
+        view.addWidget(self._build_buttons())
+        self._tip = TeachingTip.make(
+            view=view,
+            target=target,
+            duration=-1,
+            tailPosition=step.tail_position,
+            parent=self._window,
+            isDeleteOnClose=True,
+        )
+        if hasattr(self._tip, "raise_"):
+            self._tip.raise_()
+
+    def _build_buttons(self) -> QWidget:
+        """构建当前步骤的操作按钮。"""
+
+        row = QWidget()
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        layout.addStretch(1)
+
+        skip_button = PushButton("跳过")
+        skip_button.clicked.connect(self._skip)
+        layout.addWidget(skip_button, 0, Qt.AlignmentFlag.AlignRight)
+
+        step = self._steps[self._index]
+        if step.allow_next:
+            next_button = PrimaryPushButton("完成" if self._index >= len(self._steps) - 1 else "下一步")
+            next_button.clicked.connect(self._finish if self._index >= len(self._steps) - 1 else self._next)
+            layout.addWidget(next_button, 0, Qt.AlignmentFlag.AlignRight)
+        return row
+
+    def _switch_to_step_page(self, step: TourStep) -> None:
+        """按步骤切换到对应页面。"""
+
+        if step.page_name == "navigation":
+            return
+        page = self._page_for(step.page_name)
+        if page is None or self._current_page() is page:
+            return
+        self._route_settle_pending = True
+        self._window.switchTo(page)
+
+    def _ensure_visible(self, step: TourStep, target: QWidget) -> None:
+        """尽量滚动到目标控件位置。"""
+
+        page = self._page_for(step.page_name)
+        ensure = getattr(page, "ensureWidgetVisible", None)
+        if callable(ensure):
+            ensure(target)
+
+    def _on_current_page_changed(self, _index: int) -> None:
+        """用户切换到设置页后从导航入口步骤继续。"""
+
+        if not self._running or self._index >= len(self._steps):
+            return
+        step = self._steps[self._index]
+        if step.wait_for_page_name is None:
+            return
+
+        if self._current_page() is self._page_for(step.wait_for_page_name):
+            self._route_settle_pending = True
+            self._next()
+
+    def _page_for(self, name: str) -> Any:
+        """返回步骤名称对应的页面对象。"""
+
+        return {
+            "settings": self._setting_page,
+            "execution": self._execution_page,
+            "overview": self._overview_page,
+        }.get(name)
+
+    def _current_page(self) -> Any:
+        """返回当前显示页面。"""
+
+        current_widget = getattr(getattr(self._window, "stackedWidget", None), "currentWidget", None)
+        return current_widget() if callable(current_widget) else None
+
+    def _step_delay(self, step: TourStep) -> int:
+        """返回展示当前步骤前应等待的时间。"""
+
+        if step.page_name == "navigation":
+            return _NAV_STEP_DELAY_MS
+        if self._route_settle_pending:
+            self._route_settle_pending = False
+            return _ROUTE_SETTLE_DELAY_MS
+        return _NORMAL_STEP_DELAY_MS
+
+    def _close_tip(self) -> None:
+        """关闭当前 TeachingTip。"""
+
+        if self._tip is not None:
+            self._tip.close()
+            self._tip = None
+
+    def _show_mask(self, target: QWidget) -> None:
+        """展示蒙版并让当前目标区域可点击。"""
+
+        self._close_mask()
+        self._mask = OnboardingMask(self._window)
+        self._mask.set_target(target)
+        self._mask.show()
+        self._mask.raise_()
+        for delay in _MASK_RESYNC_DELAYS_MS:
+            QTimer.singleShot(delay, self._sync_mask)
+
+    def _sync_mask(self) -> None:
+        """动画或布局变化后重算蒙版透明区域。"""
+
+        if self._mask is not None:
+            self._mask.sync()
+
+    def _close_mask(self) -> None:
+        """关闭当前蒙版。"""
+
+        if self._mask is not None:
+            self._mask.close()
+            self._mask.deleteLater()
+            self._mask = None
+
+    def _target_nav_for(self, page_name: str) -> QWidget | None:
+        """返回左侧导航中的页面入口。"""
+
+        nav = getattr(self._window, "navigationInterface", None)
+        if nav is None:
+            return None
+        page = self._page_for(page_name)
+        route_key = page.objectName() if page is not None and callable(getattr(page, "objectName", None)) else ""
+        if not route_key:
+            route_key = {
+                "settings": "SettingPage",
+                "execution": "ExecutionPage",
+                "overview": "OverviewPage",
+            }.get(page_name, "")
+        try:
+            return nav.widget(route_key)
+        except Exception:
+            return None
+
+    def _build_steps(self) -> tuple[TourStep, ...]:
+        """构建第一版新手引导步骤。"""
+
+        return (
+            TourStep(
+                key="settings-entry",
+                page_name="navigation",
+                target=lambda: self._target_nav_for("settings"),
+                title="先打开全局设置",
+                content="全局设置在左侧导航栏底部。请点击这个入口，进入设置页后我会继续说明游戏目录和输出目录。",
+                allow_next=False,
+                wait_for_page_name="settings",
+            ),
+            TourStep(
+                key="source-mode",
+                page_name="settings",
+                target=lambda: getattr(self._setting_page, "sourceModeCard", None),
+                title="来源模式",
+                content="多数用户保持本地模式即可，它会读取你电脑里的英雄联盟客户端目录。远程模式适合没有完整游戏目录的情况，第一步不用改。",
+            ),
+            TourStep(
+                key="game-path",
+                page_name="settings",
+                target=lambda: getattr(self._setting_page, "gamePathCard", None),
+                title="游戏位置",
+                content="这里选择英雄联盟安装相关位置，不需要精确理解根目录。可以选安装目录、Game 目录或 LeagueClient 目录，程序会自动识别真正的游戏目录。",
+            ),
+            TourStep(
+                key="output-path",
+                page_name="settings",
+                target=lambda: getattr(self._setting_page, "outputPathCard", None),
+                title="输出目录",
+                content="输出目录保存导出的 .wem、可选 .wav、事件映射文件和报告。建议选一个容易找到的空文件夹，不要放进游戏安装目录。",
+            ),
+            TourStep(
+                key="execution-entry",
+                page_name="navigation",
+                target=lambda: self._target_nav_for("execution"),
+                title="打开执行中心",
+                content="执行中心在左侧导航栏。请点击它，进入后我会说明怎样选择目标、音频范围和任务类型。",
+                allow_next=False,
+                wait_for_page_name="execution",
+            ),
+            TourStep(
+                key="task-scope",
+                page_name="execution",
+                target=lambda: getattr(self._execution_page, "taskBuilderPanel", None),
+                title="创建任务",
+                content="执行中心决定这次要处理哪些英雄或地图，以及要做解包、转码还是事件映射。先选少量目标测试，再扩大范围更稳。",
+            ),
+            TourStep(
+                key="audio-range",
+                page_name="execution",
+                target=lambda: getattr(self._execution_page, "vo_filter", None),
+                title="音频范围",
+                content="VO 是英雄语音，通常是台词和播报；SFX 是技能、环境等音效；MUSIC 是音乐。默认先处理 VO，适合大多数语音导出需求。",
+            ),
+            TourStep(
+                key="wav-transcode",
+                page_name="execution",
+                target=lambda: getattr(self._execution_page, "wav_task_cb", None),
+                title="音频转码",
+                content="解包会得到原始 .wem。只有勾选音频转码后，格式选项才会启用，用来额外导出 wav 等更容易播放的文件。",
+            ),
+            TourStep(
+                key="event-mapping",
+                page_name="execution",
+                target=lambda: getattr(self._execution_page, "mapping_task_cb", None),
+                title="事件映射",
+                content="事件映射用于把游戏事件名和音频文件关联起来。想查某句语音对应哪个事件时再勾选；只想导出音频可以不选。",
+            ),
+            TourStep(
+                key="overview-entry",
+                page_name="navigation",
+                target=lambda: self._target_nav_for("overview"),
+                title="打开实体总览",
+                content="实体总览在左侧导航栏。请点击它，进入后我会说明如何查看英雄、地图和事件音频。",
+                allow_next=False,
+                wait_for_page_name="overview",
+            ),
+            TourStep(
+                key="overview-list",
+                page_name="overview",
+                target=lambda: getattr(self._overview_page, "entityListPanel", None),
+                title="实体总览",
+                content="这里查看英雄和地图的数据状态，也可以把选中的实体发送到执行中心，避免手动输入编号或别名。",
+            ),
+            TourStep(
+                key="overview-preview",
+                page_name="overview",
+                target=lambda: getattr(
+                    self._overview_page,
+                    "previewPanel",
+                    getattr(self._overview_page, "audio_preview_tree", None),
+                ),
+                title="事件与音频预览",
+                content="更新和映射完成后，可以在这里查看事件树、音频列表和试听结果。看不到内容时，通常需要先更新数据或执行映射。",
+            ),
+            TourStep(
+                key="settings-tools-entry",
+                page_name="navigation",
+                target=lambda: self._target_nav_for("settings"),
+                title="回到全局设置",
+                content="最后回到全局设置，看一下高级工具路径。请点击左侧的全局设置入口。",
+                allow_next=False,
+                wait_for_page_name="settings",
+            ),
+            TourStep(
+                key="advanced-tools",
+                page_name="settings",
+                target=lambda: getattr(self._setting_page, "wwiserCard", None),
+                title="高级工具",
+                content="wwiser 和 vgmstream-cli 现在不是普通流程必填项。默认会使用内置能力；遇到高级兼容需求时，再按文档设置这些路径。",
+            ),
+        )
+
+
+__all__ = ["GUIDE_VERSION", "OnboardingMask", "OnboardingTourController", "TourStep"]

--- a/src/lol_audio_unpack/gui/controllers/onboarding_state.py
+++ b/src/lol_audio_unpack/gui/controllers/onboarding_state.py
@@ -1,0 +1,7 @@
+"""GUI 新手引导状态常量。"""
+
+from __future__ import annotations
+
+GUIDE_VERSION = "2026-06-gui-basics"
+
+__all__ = ["GUIDE_VERSION"]

--- a/src/lol_audio_unpack/gui/view/setting_page.py
+++ b/src/lol_audio_unpack/gui/view/setting_page.py
@@ -1,5 +1,6 @@
 ﻿from __future__ import annotations
 
+from pathlib import Path
 from time import perf_counter
 from weakref import ref
 
@@ -29,6 +30,7 @@ from lol_audio_unpack.gui.common import (
     format_path_for_display,
     is_remote_panel_visible,
     needs_remote_mode_fallback,
+    show_feedback_infobar,
 )
 from lol_audio_unpack.gui.common.page_style import (
     apply_page_content_margins,
@@ -36,6 +38,8 @@ from lol_audio_unpack.gui.common.page_style import (
 )
 from lol_audio_unpack.gui.controllers import RemoteSourceController
 from lol_audio_unpack.gui.controllers.contracts import RuntimeLoggingConfig
+from lol_audio_unpack.gui.controllers.game_path_resolver import resolve_game_path as resolve_selected_game_path
+from lol_audio_unpack.gui.controllers.onboarding_state import GUIDE_VERSION
 from lol_audio_unpack.gui.controllers.path_picker import (
     apply_path_card_label,
     pick_and_apply_directory,
@@ -276,6 +280,13 @@ class SettingPage(SmoothScrollArea):
         self.logLevelCard = self.appearancePanel.logLevelCard
         self.consoleLogLevelCard = self.appearancePanel.consoleLogLevelCard
         self.fileLogLevelCard = self.appearancePanel.fileLogLevelCard
+        self.onboardingResetCard = PushSettingCard(
+            "重置",
+            FIF.INFO,
+            "重置引导",
+            "清除新手引导状态，下次启动后自动显示。",
+        )
+        self.personalGroup.addSettingCard(self.onboardingResetCard)
         self.expandLayout.addWidget(self.personalGroup)
 
     # ------------------------------------------------------------------
@@ -408,19 +419,7 @@ class SettingPage(SmoothScrollArea):
         self.sourceModeCard.comboBox.currentTextChanged.connect(self._on_source_mode_changed)
 
         # 目录 / 文件选择按钮
-        self.gamePathCard.clicked.connect(
-            lambda: pick_and_apply_directory(
-                title="选择游戏根目录",
-                host=self,
-                current=str(self._cfg.resolve_game_path() or ""),
-                assign=lambda path: setattr(self._cfg, "game_path", path),
-                save=self._cfg.save,
-                card=self.gamePathCard,
-                default="",
-                changed_signal=self.game_path_changed,
-                emit_context_changed=self.shared_context_input_changed.emit,
-            )
-        )
+        self.gamePathCard.clicked.connect(self._pick_game_path)
         self.outputPathCard.clicked.connect(
             lambda: pick_and_apply_directory(
                 title="选择输出目录",
@@ -460,6 +459,7 @@ class SettingPage(SmoothScrollArea):
                 changed_signal=self.vgmstream_path_changed,
             )
         )
+        self.onboardingResetCard.clicked.connect(self._reset_onboarding_state)
 
         # 远程配置草稿
         self.remoteSourcePanel.draft_changed.connect(self._save_remote_draft_config)
@@ -509,6 +509,73 @@ class SettingPage(SmoothScrollArea):
     # ------------------------------------------------------------------
     # 目录 / 文件选择槽
     # ------------------------------------------------------------------
+
+    def _pick_game_path(self) -> None:
+        """选择并归一化本地游戏目录。"""
+
+        selected = pick_directory(
+            title="选择英雄联盟安装位置",
+            host=self,
+            current=str(self._cfg.resolve_game_path() or ""),
+        )
+        if not selected:
+            return
+
+        result = resolve_selected_game_path(selected)
+        if not result.resolved or result.root is None:
+            if result.reason == "ambiguous":
+                self._show_feedback(
+                    title="找到多个可能的游戏目录",
+                    content="请选择更具体的英雄联盟安装位置，例如具体游戏目录下的 Game 或 LeagueClient。",
+                    level="warning",
+                )
+                return
+
+            self._show_feedback(
+                title="未识别到游戏目录",
+                content="请选择英雄联盟安装相关位置，例如安装目录、Game 目录或 LeagueClient 目录。",
+                level="warning",
+            )
+            return
+
+        root = result.root.resolve(strict=False)
+        normalized = str(root)
+        self._cfg.game_path = normalized
+        self._cfg.save()
+        apply_path_card_label(self.gamePathCard, normalized)
+        self.game_path_changed.emit(normalized)
+        self.shared_context_input_changed.emit()
+
+        selected_path = Path(selected).resolve(strict=False)
+        version_text = f"版本：{result.version}" if result.version else "版本：未知"
+        if selected_path == root:
+            content = f"当前目录符合英雄联盟现行客户端结构。{version_text}"
+        else:
+            content = (
+                f"你选择的是 {format_path_for_display(str(selected_path))}，"
+                f"已自动识别为 {format_path_for_display(normalized)}。{version_text}"
+            )
+        self._show_feedback(title="已识别游戏目录", content=content, level="success")
+
+    def _reset_onboarding_state(self) -> None:
+        """重置新手引导状态，并等下次启动自动显示。"""
+
+        self._cfg.reset_onboarding(GUIDE_VERSION)
+        self._show_feedback(
+            title="已重置",
+            content="下次启动后会自动显示新手引导。",
+            level="success",
+        )
+
+    def _show_feedback(self, *, title: str, content: str, level: str) -> None:
+        """使用统一 InfoBar 显示设置页反馈。"""
+
+        show_feedback_infobar(
+            parent=self.window() or self,
+            title=title,
+            content=content,
+            level=level,
+        )
 
     # ------------------------------------------------------------------
     # 动态显隐

--- a/src/lol_audio_unpack/gui/view/settings/tool_path_panel.py
+++ b/src/lol_audio_unpack/gui/view/settings/tool_path_panel.py
@@ -49,13 +49,13 @@ class ToolPathPanel:
             "选择文件",
             FIF.DEVELOPER_TOOLS,
             "wwiser 路径",
-            "Mapping 功能依赖此工具 (wwiser.py)  —  https://github.com/bnnm/wwiser",
+            "可选兼容工具。默认使用内置 NativeHIRC；需要旧 wwiser 流程时再设置。",
         )
         self.vgmstreamCard = PushSettingCard(
             "选择文件",
             FIF.COMMAND_PROMPT,
             "vgmstream-cli 路径",
-            "音频转码依赖此工具 (vgmstream-cli.exe)  —  将 .wem 批量转成 .wav",
+            "可选外部工具。默认使用内置 pyvgmstream；高级兼容场景再设置。",
         )
 
         self.group.addSettingCard(self.wwiserCard)

--- a/src/lol_audio_unpack/gui/window.py
+++ b/src/lol_audio_unpack/gui/window.py
@@ -44,6 +44,7 @@ from lol_audio_unpack.gui.controllers import (
     SharedDataController,
 )
 from lol_audio_unpack.gui.controllers.contracts import RuntimeLoggingConfig
+from lol_audio_unpack.gui.controllers.onboarding import OnboardingTourController
 from lol_audio_unpack.gui.controllers.shared_data import (
     build_shared_entity_reader_signature,
     build_shared_entity_scan_signature,
@@ -134,6 +135,7 @@ class MainWindow(FluentWindow):
         previous_mark = _log_window_stage("主题变更信号连接完成", startup_begin, previous_mark)
 
         self._shared_data_controller: SharedDataController | None = None
+        self._onboarding_controller: OnboardingTourController | None = None
         self._window_material_bootstrapped = False
         self._last_window_material_logged_state: bool | None = None
         self._dev_console_controller: DevConsoleController | None = None
@@ -204,6 +206,16 @@ class MainWindow(FluentWindow):
         # 连接设置页面和首页
         self._connect_pages()
         previous_mark = _log_window_stage("页面连接与首轮数据加载触发完成", startup_begin, previous_mark)
+        self._onboarding_controller = OnboardingTourController(
+            window=self,
+            config=cfg,
+            setting_page=self.settingInterface,
+            execution_page=self.executionInterface,
+            overview_page=self.overviewInterface,
+            has_active_work=self._has_active_background_work,
+        )
+        QTimer.singleShot(600, self._onboarding_controller.start_if_needed)
+        previous_mark = _log_window_stage("新手引导启动检查已安排", startup_begin, previous_mark)
         return previous_mark
 
     def _initWindow(self):
@@ -306,6 +318,8 @@ class MainWindow(FluentWindow):
         should_force_quit = self._has_active_background_work()
         if should_force_quit:
             self._shutdown_background_work()
+        if self._onboarding_controller is not None:
+            self._onboarding_controller.close()
         self._disconnect_theme_material_listener()
         self._unregister_app_event_filter()
         super().closeEvent(event)

--- a/tests/gui/test_game_path_resolver.py
+++ b/tests/gui/test_game_path_resolver.py
@@ -1,0 +1,145 @@
+"""GUI 游戏目录识别测试。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lol_audio_unpack.gui.controllers.game_path_resolver import resolve_game_path
+
+
+def _write_game_root(root: Path, *, version: str = "16.11.1234") -> Path:
+    """写入最小可识别的现行客户端目录结构。"""
+
+    game_dir = root / "Game"
+    lcu_dir = root / "LeagueClient"
+    plugin_dir = lcu_dir / "Plugins" / "rcp-be-lol-game-data"
+    champions_dir = game_dir / "DATA" / "FINAL" / "Champions"
+    maps_dir = game_dir / "DATA" / "FINAL" / "Maps" / "Shipping"
+
+    for path in (game_dir, plugin_dir, champions_dir, maps_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    (game_dir / "content-metadata.json").write_text(json.dumps({"version": version}), encoding="utf-8")
+    (game_dir / "League of Legends.exe").write_bytes(b"")
+    (lcu_dir / "LeagueClient.exe").write_bytes(b"")
+    return root
+
+
+def test_resolves_real_game_root(tmp_path: Path) -> None:
+    """选择真实客户端根目录时应直接识别。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root)
+
+    assert result.resolved is True
+    assert result.root == root
+    assert result.version == "16.11"
+    assert result.reason == "resolved"
+
+
+def test_resolves_game_subdirectory(tmp_path: Path) -> None:
+    """选择 Game 目录时应回推到客户端根目录。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root / "Game")
+
+    assert result.resolved is True
+    assert result.root == root
+
+
+def test_resolves_league_client_subdirectory(tmp_path: Path) -> None:
+    """选择 LeagueClient 目录时应回推到客户端根目录。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root / "LeagueClient")
+
+    assert result.resolved is True
+    assert result.root == root
+
+
+def test_resolves_lcu_plugin_directory(tmp_path: Path) -> None:
+    """选择 LCU 插件目录时应回推到客户端根目录。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root / "LeagueClient" / "Plugins" / "rcp-be-lol-game-data")
+
+    assert result.resolved is True
+    assert result.root == root
+
+
+def test_resolves_champions_resource_directory(tmp_path: Path) -> None:
+    """选择英雄资源目录时应回推到客户端根目录。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root / "Game" / "DATA" / "FINAL" / "Champions")
+
+    assert result.resolved is True
+    assert result.root == root
+
+
+def test_resolves_maps_shipping_directory(tmp_path: Path) -> None:
+    """选择地图资源目录时应回推到客户端根目录。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root / "Game" / "DATA" / "FINAL" / "Maps" / "Shipping")
+
+    assert result.resolved is True
+    assert result.root == root
+
+
+def test_resolves_game_binary_file_path(tmp_path: Path) -> None:
+    """直接传入游戏二进制文件路径时应支持后续入口复用。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+
+    result = resolve_game_path(root / "Game" / "League of Legends.exe")
+
+    assert result.resolved is True
+    assert result.root == root
+
+
+def test_rejects_loose_binary_marker_without_metadata(tmp_path: Path) -> None:
+    """不能只凭二进制文件名判定游戏目录。"""
+
+    root = tmp_path / "英雄联盟"
+    game_dir = root / "Game"
+    game_dir.mkdir(parents=True)
+    (game_dir / "League of Legends.exe").write_bytes(b"")
+
+    result = resolve_game_path(root)
+
+    assert result.resolved is False
+    assert result.root is None
+    assert result.reason == "not_found"
+
+
+def test_reports_ambiguous_parent_with_multiple_game_roots(tmp_path: Path) -> None:
+    """上级目录存在多个强匹配时不应静默猜测。"""
+
+    parent = tmp_path / "WeGameApps"
+    _write_game_root(parent / "英雄联盟")
+    _write_game_root(parent / "英雄联盟-PBE", version="16.12.1")
+
+    result = resolve_game_path(parent)
+
+    assert result.resolved is False
+    assert result.root is None
+    assert result.reason == "ambiguous"
+    assert {probe.root.name for probe in result.candidates} == {"英雄联盟", "英雄联盟-PBE"}
+
+
+def test_invalid_path_returns_not_found(tmp_path: Path) -> None:
+    """不存在的路径应返回未识别而不是抛出异常。"""
+
+    result = resolve_game_path(tmp_path / "missing")
+
+    assert result.resolved is False
+    assert result.root is None
+    assert result.reason == "not_found"

--- a/tests/gui/test_gui_config_onboarding.py
+++ b/tests/gui/test_gui_config_onboarding.py
@@ -1,0 +1,68 @@
+"""GUI 新手引导状态配置测试。"""
+
+from __future__ import annotations
+
+from lol_audio_unpack.gui.common.gui_config import GuiConfig
+
+GUIDE_VERSION = "2026-06-gui-basics"
+OLD_GUIDE_VERSION = "2026-05-old-guide"
+
+
+def test_fresh_config_should_show_onboarding() -> None:
+    """首次状态应自动展示当前引导版本。"""
+
+    cfg = GuiConfig()
+
+    assert cfg.should_show_onboarding(GUIDE_VERSION) is True
+
+
+def test_completed_onboarding_should_not_show_again() -> None:
+    """完成当前引导版本后不应再次自动展示。"""
+
+    cfg = GuiConfig()
+
+    cfg.mark_onboarding_completed(GUIDE_VERSION)
+
+    assert cfg.should_show_onboarding(GUIDE_VERSION) is False
+
+
+def test_skipped_onboarding_should_not_show_again() -> None:
+    """跳过当前引导版本后不应再次自动展示。"""
+
+    cfg = GuiConfig()
+
+    cfg.mark_onboarding_skipped(GUIDE_VERSION)
+
+    assert cfg.should_show_onboarding(GUIDE_VERSION) is False
+
+
+def test_reset_completed_onboarding_should_show_again() -> None:
+    """重置已完成的当前版本后应允许下次启动展示。"""
+
+    cfg = GuiConfig()
+    cfg.mark_onboarding_completed(GUIDE_VERSION)
+
+    cfg.reset_onboarding(GUIDE_VERSION)
+
+    assert cfg.should_show_onboarding(GUIDE_VERSION) is True
+
+
+def test_reset_skipped_onboarding_should_show_again() -> None:
+    """重置已跳过的当前版本后应允许下次启动展示。"""
+
+    cfg = GuiConfig()
+    cfg.mark_onboarding_skipped(GUIDE_VERSION)
+
+    cfg.reset_onboarding(GUIDE_VERSION)
+
+    assert cfg.should_show_onboarding(GUIDE_VERSION) is True
+
+
+def test_new_onboarding_version_ignores_old_completion() -> None:
+    """新引导版本不应被旧版本的完成状态压制。"""
+
+    cfg = GuiConfig()
+
+    cfg.mark_onboarding_completed(OLD_GUIDE_VERSION)
+
+    assert cfg.should_show_onboarding(GUIDE_VERSION) is True

--- a/tests/gui/test_onboarding_controller.py
+++ b/tests/gui/test_onboarding_controller.py
@@ -1,0 +1,445 @@
+"""GUI 新手引导控制器测试。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from PySide6.QtCore import QObject, QPoint, Signal
+from PySide6.QtWidgets import QWidget
+
+from lol_audio_unpack.gui.controllers import onboarding as onboarding_module
+from lol_audio_unpack.gui.controllers.onboarding import OnboardingMask, OnboardingTourController
+from lol_audio_unpack.gui.controllers.onboarding_state import GUIDE_VERSION
+
+MIN_ROUTE_SETTLE_DELAY_MS = 300
+
+
+class _FakeConfig:
+    """记录新手引导状态调用的配置替身。"""
+
+    def __init__(self, *, should_show: bool = True) -> None:
+        self.should_show = should_show
+        self.completed: list[str] = []
+        self.skipped: list[str] = []
+
+    def should_show_onboarding(self, guide_version: str) -> bool:
+        return self.should_show and guide_version == GUIDE_VERSION
+
+    def mark_onboarding_completed(self, guide_version: str) -> None:
+        self.completed.append(guide_version)
+
+    def mark_onboarding_skipped(self, guide_version: str) -> None:
+        self.skipped.append(guide_version)
+
+
+class _FakeWindow(QWidget):
+    """记录页面切换调用的窗口替身。"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.resize(420, 320)
+        self.switched: list[object] = []
+        self.settingNav = QWidget(self)
+        self.settingNav.setGeometry(12, 250, 120, 42)
+        self.executionNav = QWidget(self)
+        self.executionNav.setGeometry(12, 92, 120, 42)
+        self.overviewNav = QWidget(self)
+        self.overviewNav.setGeometry(12, 140, 120, 42)
+        self.settingNav.show()
+        self.executionNav.show()
+        self.overviewNav.show()
+        self.navigationInterface = SimpleNamespace(widget=self._navigation_widget)
+        self.stackedWidget = _FakeStack()
+
+    def switchTo(self, page) -> None:
+        self.switched.append(page)
+        if isinstance(page, QWidget):
+            page.show()
+        self.stackedWidget.setCurrentWidget(page)
+
+    def _navigation_widget(self, route_key: str) -> QWidget:
+        items = {
+            "SettingPage": self.settingNav,
+            "ExecutionPage": self.executionNav,
+            "OverviewPage": self.overviewNav,
+        }
+        if route_key not in items:
+            raise KeyError(route_key)
+        return items[route_key]
+
+
+class _FakeStack(QObject):
+    """提供当前页变更信号的 stackedWidget 替身。"""
+
+    currentChanged = Signal(int)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._current = None
+
+    def currentWidget(self):
+        return self._current
+
+    def setCurrentWidget(self, widget) -> None:
+        self._current = widget
+        self.currentChanged.emit(0)
+
+
+class _FakeTip:
+    """记录关闭状态的 TeachingTip 替身。"""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _widget(qtbot, parent: QWidget | None = None) -> QWidget:
+    widget = QWidget(parent)
+    qtbot.addWidget(widget)
+    widget.show()
+    return widget
+
+
+def _page(qtbot, name: str, **targets: QWidget | None) -> SimpleNamespace:
+    page = SimpleNamespace(**targets)
+    page.ensureWidgetVisible = lambda _target: None
+    page.objectName = lambda: name
+    for target in targets.values():
+        if target is not None:
+            target.show()
+    return page
+
+
+def _build_controller(qtbot, monkeypatch, *, should_show: bool = True, active: bool = False, missing_first=False):
+    created: list[dict[str, object]] = []
+
+    def _make_tip(**kwargs):
+        tip = _FakeTip()
+        kwargs["tip"] = tip
+        created.append(kwargs)
+        return tip
+
+    monkeypatch.setattr(onboarding_module.QTimer, "singleShot", lambda _delay, callback: callback())
+    monkeypatch.setattr(onboarding_module.TeachingTip, "make", _make_tip)
+
+    window = _FakeWindow()
+    qtbot.addWidget(window)
+    window.show()
+    setting_page = _page(
+        qtbot,
+        "SettingPage",
+        sourceModeCard=None if missing_first else _widget(qtbot),
+        gamePathCard=_widget(qtbot),
+        outputPathCard=_widget(qtbot),
+        wwiserCard=_widget(qtbot),
+    )
+    execution_page = _page(
+        qtbot,
+        "ExecutionPage",
+        taskBuilderPanel=_widget(qtbot),
+        vo_filter=_widget(qtbot),
+        wav_task_cb=_widget(qtbot),
+        mapping_task_cb=_widget(qtbot),
+    )
+    overview_page = _page(
+        qtbot,
+        "OverviewPage",
+        entityListPanel=_widget(qtbot),
+        previewPanel=_widget(qtbot),
+        audio_preview_tree=_widget(qtbot),
+    )
+    config = _FakeConfig(should_show=should_show)
+    controller = OnboardingTourController(
+        window=window,
+        config=config,
+        setting_page=setting_page,
+        execution_page=execution_page,
+        overview_page=overview_page,
+        has_active_work=lambda: active,
+    )
+    pages = SimpleNamespace(setting=setting_page, execution=execution_page, overview=overview_page)
+    return controller, config, window, created, pages
+
+
+def test_start_if_needed_ignores_completed_state(qtbot, monkeypatch) -> None:
+    """当前引导版本已处理时不应创建气泡。"""
+
+    controller, _config, window, created, _pages = _build_controller(
+        qtbot,
+        monkeypatch,
+        should_show=False,
+    )
+
+    controller.start_if_needed()
+
+    assert created == []
+    assert window.switched == []
+
+
+def test_start_if_needed_ignores_active_background_work(qtbot, monkeypatch) -> None:
+    """存在后台任务时不应自动弹出引导。"""
+
+    controller, _config, window, created, _pages = _build_controller(qtbot, monkeypatch, active=True)
+
+    controller.start_if_needed()
+
+    assert created == []
+    assert window.switched == []
+
+
+def test_start_anchors_to_settings_navigation_without_switching_page(qtbot, monkeypatch) -> None:
+    """首次启动时应先提示设置入口，而不是直接跳转到设置页。"""
+
+    controller, _config, window, created, _pages = _build_controller(qtbot, monkeypatch)
+
+    controller.start()
+
+    assert window.switched == []
+    assert created[0]["target"] is window.settingNav
+    assert created[0]["duration"] == -1
+
+
+def test_switching_to_settings_advances_from_navigation_step(qtbot, monkeypatch) -> None:
+    """用户点击设置入口后，引导应进入设置页内部步骤。"""
+
+    controller, _config, window, created, pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+    first_tip = created[0]["tip"]
+
+    window.stackedWidget.setCurrentWidget(pages.setting)
+
+    assert first_tip.closed is True
+    assert created[1]["target"] is pages.setting.sourceModeCard
+
+
+def test_route_change_waits_before_showing_page_step(qtbot, monkeypatch) -> None:
+    """路由变化后应等待页面动画结束再计算目标位置。"""
+
+    callbacks: list[tuple[int, object]] = []
+    created: list[dict[str, object]] = []
+
+    def _make_tip(**kwargs):
+        kwargs["tip"] = _FakeTip()
+        created.append(kwargs)
+        return kwargs["tip"]
+
+    monkeypatch.setattr(onboarding_module.QTimer, "singleShot", lambda delay, callback: callbacks.append((delay, callback)))
+    monkeypatch.setattr(onboarding_module.TeachingTip, "make", _make_tip)
+    window = _FakeWindow()
+    qtbot.addWidget(window)
+    window.show()
+    setting_page = _page(
+        qtbot,
+        "SettingPage",
+        sourceModeCard=_widget(qtbot),
+        gamePathCard=_widget(qtbot),
+        outputPathCard=_widget(qtbot),
+        wwiserCard=_widget(qtbot),
+    )
+    controller = OnboardingTourController(
+        window=window,
+        config=_FakeConfig(),
+        setting_page=setting_page,
+        execution_page=_page(qtbot, "ExecutionPage"),
+        overview_page=_page(qtbot, "OverviewPage"),
+        has_active_work=lambda: False,
+    )
+
+    controller.start()
+    callbacks.pop(0)[1]()
+    window.stackedWidget.setCurrentWidget(setting_page)
+
+    assert callbacks[-1][0] >= MIN_ROUTE_SETTLE_DELAY_MS
+    callbacks.pop()[1]()
+    assert created[-1]["target"] is setting_page.sourceModeCard
+
+
+def test_next_closes_previous_tip_and_opens_next(qtbot, monkeypatch) -> None:
+    """进入下一步时应关闭旧气泡并创建新气泡。"""
+
+    controller, _config, _window, created, pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+    first_tip = created[0]["tip"]
+
+    controller._next()
+
+    assert first_tip.closed is True
+    assert created[1]["target"] is pages.setting.sourceModeCard
+
+
+def test_next_from_settings_prompts_execution_navigation(qtbot, monkeypatch) -> None:
+    """设置页讲完后应提示用户自己点击执行中心。"""
+
+    controller, _config, window, created, pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+    window.stackedWidget.setCurrentWidget(pages.setting)
+    created.clear()
+    window.switched.clear()
+
+    controller._next()
+    controller._next()
+    controller._next()
+
+    assert window.switched == []
+    assert created[-1]["target"] is window.executionNav
+
+
+def test_switching_to_execution_advances_from_navigation_step(qtbot, monkeypatch) -> None:
+    """用户点击执行中心后，引导应进入执行中心内部步骤。"""
+
+    controller, _config, window, created, pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+    window.stackedWidget.setCurrentWidget(pages.setting)
+    controller._next()
+    controller._next()
+    controller._next()
+    execution_tip = created[-1]["tip"]
+
+    window.stackedWidget.setCurrentWidget(pages.execution)
+
+    assert execution_tip.closed is True
+    assert created[-1]["target"] is pages.execution.taskBuilderPanel
+
+
+def test_next_from_execution_prompts_overview_navigation(qtbot, monkeypatch) -> None:
+    """执行中心讲完后应提示用户自己点击实体总览。"""
+
+    controller, _config, window, created, pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+    window.stackedWidget.setCurrentWidget(pages.setting)
+    controller._next()
+    controller._next()
+    controller._next()
+    window.stackedWidget.setCurrentWidget(pages.execution)
+    created.clear()
+    window.switched.clear()
+
+    controller._next()
+    controller._next()
+    controller._next()
+    controller._next()
+
+    assert window.switched == []
+    assert created[-1]["target"] is window.overviewNav
+
+
+def test_skip_marks_state_and_closes_tip(qtbot, monkeypatch) -> None:
+    """跳过引导时应持久化跳过状态并关闭气泡。"""
+
+    controller, config, _window, created, _pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+
+    controller._skip()
+
+    assert config.skipped == [GUIDE_VERSION]
+    assert created[0]["tip"].closed is True
+
+
+def test_finish_marks_state_and_closes_tip(qtbot, monkeypatch) -> None:
+    """完成引导时应持久化完成状态并关闭气泡。"""
+
+    controller, config, _window, created, _pages = _build_controller(qtbot, monkeypatch)
+    controller.start()
+
+    controller._finish()
+
+    assert config.completed == [GUIDE_VERSION]
+    assert created[0]["tip"].closed is True
+
+
+def test_missing_target_skips_to_next_available_step(qtbot, monkeypatch) -> None:
+    """目标控件缺失时应跳到下一个可用步骤。"""
+
+    controller, _config, _window, created, pages = _build_controller(
+        qtbot,
+        monkeypatch,
+        missing_first=True,
+    )
+
+    controller.start()
+
+    controller._next()
+
+    assert created[-1]["target"] is pages.setting.gamePathCard
+
+
+def test_close_before_delayed_show_prevents_tip_creation(qtbot, monkeypatch) -> None:
+    """关闭控制器后，尚未执行的延迟回调不应再创建气泡。"""
+
+    callbacks = []
+    created: list[dict[str, object]] = []
+
+    def _make_tip(**kwargs):
+        kwargs["tip"] = _FakeTip()
+        created.append(kwargs)
+        return kwargs["tip"]
+
+    monkeypatch.setattr(onboarding_module.QTimer, "singleShot", lambda _delay, callback: callbacks.append(callback))
+    monkeypatch.setattr(onboarding_module.TeachingTip, "make", _make_tip)
+
+    window = _FakeWindow()
+    qtbot.addWidget(window)
+    setting_page = _page(
+        qtbot,
+        "SettingPage",
+        sourceModeCard=_widget(qtbot),
+        gamePathCard=_widget(qtbot),
+        outputPathCard=_widget(qtbot),
+        wwiserCard=_widget(qtbot),
+    )
+    execution_page = _page(qtbot, "ExecutionPage")
+    overview_page = _page(qtbot, "OverviewPage")
+    controller = OnboardingTourController(
+        window=window,
+        config=_FakeConfig(),
+        setting_page=setting_page,
+        execution_page=execution_page,
+        overview_page=overview_page,
+        has_active_work=lambda: False,
+    )
+
+    controller.start()
+    controller.close()
+    callbacks[0]()
+
+    assert created == []
+
+
+def test_onboarding_mask_covers_outside_target_and_leaves_target_hole(qtbot) -> None:
+    """蒙版应覆盖非目标区域，并在目标控件周围留出透明点击区域。"""
+
+    host = QWidget()
+    host.resize(300, 200)
+    target = QWidget(host)
+    target.setGeometry(80, 60, 80, 40)
+    qtbot.addWidget(host)
+    host.show()
+    target.show()
+
+    mask = OnboardingMask(host)
+    mask.set_target(target)
+    mask.show()
+
+    assert mask.mask().contains(QPoint(10, 10)) is True
+    assert mask.mask().contains(QPoint(120, 80)) is False
+
+
+def test_onboarding_mask_uses_rounded_target_hole(qtbot) -> None:
+    """透明区域应使用圆角，避免目标高亮边缘显得生硬。"""
+
+    host = QWidget()
+    host.resize(300, 200)
+    target = QWidget(host)
+    target.setGeometry(80, 60, 80, 40)
+    qtbot.addWidget(host)
+    host.show()
+    target.show()
+
+    mask = OnboardingMask(host, padding=0, radius=16)
+    mask.set_target(target)
+    mask.show()
+
+    assert mask.mask().contains(QPoint(82, 62)) is True
+    assert mask.mask().contains(QPoint(120, 80)) is False

--- a/tests/gui/test_setting_page_game_path.py
+++ b/tests/gui/test_setting_page_game_path.py
@@ -1,0 +1,64 @@
+"""设置页游戏目录选择测试。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lol_audio_unpack.gui.view import setting_page as setting_page_module
+from lol_audio_unpack.gui.view.setting_page import SettingPage
+
+
+def _write_game_root(root: Path) -> Path:
+    """写入最小可识别的游戏目录。"""
+
+    game_dir = root / "Game"
+    lcu_dir = root / "LeagueClient"
+    (game_dir / "DATA" / "FINAL" / "Champions").mkdir(parents=True)
+    (game_dir / "DATA" / "FINAL" / "Maps" / "Shipping").mkdir(parents=True)
+    (lcu_dir / "Plugins" / "rcp-be-lol-game-data").mkdir(parents=True)
+    (game_dir / "content-metadata.json").write_text(json.dumps({"version": "16.11.1"}), encoding="utf-8")
+    (game_dir / "League of Legends.exe").write_bytes(b"")
+    (lcu_dir / "LeagueClient.exe").write_bytes(b"")
+    return root
+
+
+def test_setting_page_game_picker_saves_normalized_root(qtbot, tmp_path: Path, monkeypatch) -> None:
+    """用户选到 Game 目录时设置页应保存归一化后的根目录。"""
+
+    root = _write_game_root(tmp_path / "英雄联盟")
+    page = SettingPage()
+    qtbot.addWidget(page)
+    notices: list[dict[str, str]] = []
+    changed: list[str] = []
+    shared_changed: list[bool] = []
+    page.game_path_changed.connect(changed.append)
+    page.shared_context_input_changed.connect(lambda: shared_changed.append(True))
+    monkeypatch.setattr(setting_page_module, "pick_directory", lambda **_kwargs: str(root / "Game"))
+    monkeypatch.setattr(setting_page_module, "show_feedback_infobar", lambda **kwargs: notices.append(kwargs), raising=False)
+
+    page._pick_game_path()
+
+    assert Path(page.config.game_path) == root.resolve(strict=False)
+    assert [Path(path) for path in changed] == [root.resolve(strict=False)]
+    assert shared_changed == [True]
+    assert notices[-1]["title"] == "已识别游戏目录"
+    assert str(root.resolve(strict=False)) in notices[-1]["content"]
+
+
+def test_setting_page_game_picker_keeps_previous_path_when_invalid(qtbot, tmp_path: Path, monkeypatch) -> None:
+    """无法识别目录时不应覆盖已有游戏路径。"""
+
+    previous = tmp_path / "previous"
+    page = SettingPage()
+    qtbot.addWidget(page)
+    page.config.game_path = str(previous)
+    changed: list[str] = []
+    page.game_path_changed.connect(changed.append)
+    monkeypatch.setattr(setting_page_module, "pick_directory", lambda **_kwargs: str(tmp_path / "invalid"))
+    monkeypatch.setattr(setting_page_module, "show_feedback_infobar", lambda **_kwargs: None, raising=False)
+
+    page._pick_game_path()
+
+    assert page.config.game_path == str(previous)
+    assert changed == []

--- a/tests/gui/test_setting_page_onboarding.py
+++ b/tests/gui/test_setting_page_onboarding.py
@@ -1,0 +1,23 @@
+"""设置页新手引导入口测试。"""
+
+from __future__ import annotations
+
+from lol_audio_unpack.gui.controllers.onboarding_state import GUIDE_VERSION
+from lol_audio_unpack.gui.view import setting_page as setting_page_module
+from lol_audio_unpack.gui.view.setting_page import SettingPage
+
+
+def test_setting_page_reset_onboarding_state(qtbot, monkeypatch) -> None:
+    """重置引导入口应清除当前版本状态并提示下次启动显示。"""
+
+    page = SettingPage()
+    qtbot.addWidget(page)
+    page.config.mark_onboarding_completed(GUIDE_VERSION)
+    notices: list[dict[str, str]] = []
+    monkeypatch.setattr(setting_page_module, "show_feedback_infobar", lambda **kwargs: notices.append(kwargs))
+
+    page._reset_onboarding_state()
+
+    assert page.config.should_show_onboarding(GUIDE_VERSION) is True
+    assert notices[-1]["title"] == "已重置"
+    assert notices[-1]["content"] == "下次启动后会自动显示新手引导。"


### PR DESCRIPTION
## Why
- 降低首次使用时理解游戏目录、输出目录、执行中心和实体总览的文档依赖。

## What
- 新增 GUI 新手引导控制器、半透明蒙版、圆角高亮洞和版本状态。
- 首次启动按导航步骤引导用户进入设置、执行中心和实体总览。
- 支持在设置中“重置引导”，下次启动自动重新显示。
- 游戏目录选择后自动识别并归一化英雄联盟客户端根目录。
- 更新 wwiser 与 vgmstream 的可选工具说明。
- 补充路径识别、引导状态、设置页和引导控制器的 GUI 定向测试。

## Risk
- 兼容性影响：无。新增引导状态写入 GUI QSettings，不改变 `.lol.env` 配置语义。
- 潜在风险：引导气泡与蒙版最终视觉观感仍需要在真实窗口和不同 DPI 下人工确认。

## Test
- `uv run ruff check src/lol_audio_unpack/gui/common/gui_config.py src/lol_audio_unpack/gui/controllers/game_path_resolver.py src/lol_audio_unpack/gui/controllers/onboarding.py src/lol_audio_unpack/gui/controllers/onboarding_state.py src/lol_audio_unpack/gui/view/setting_page.py src/lol_audio_unpack/gui/view/settings/tool_path_panel.py src/lol_audio_unpack/gui/window.py tests/gui/test_game_path_resolver.py tests/gui/test_gui_config_onboarding.py tests/gui/test_onboarding_controller.py tests/gui/test_setting_page_game_path.py tests/gui/test_setting_page_onboarding.py`：All checks passed
- `uv run pytest tests/gui/test_game_path_resolver.py tests/gui/test_gui_config_onboarding.py tests/gui/test_setting_page_game_path.py tests/gui/test_setting_page_onboarding.py tests/gui/test_onboarding_controller.py tests/gui/test_gui_config.py tests/gui/test_setting_page_theme_preset.py tests/gui/test_setting_panels_module.py tests/gui/test_execution_page.py tests/gui/test_task_creation_card.py tests/gui/test_window_shell_controller.py -v`：83 passed
- `git diff --cached --check`：无输出
