### PR TITLE
chore(release): 准备 v3.7.2 正式发布

### DIFF
--- a/.github/release-notes/v3.7.2.md
+++ b/.github/release-notes/v3.7.2.md
@@ -1,0 +1,60 @@
+# Lol Audio Unpack v3.7.2
+
+`v3.7.2` 是基于 `v3.7.1` 的打包版 GUI 稳定性修复版本，重点修复创建任务二次启动、后台数据准备竞态、地图数据缺失静默无输出、配置分散、metadata 版本回退和装备查询失败不可诊断等问题。
+
+## 重要修复
+
+### 修复打包版创建任务二次启动
+
+- 修复打包版 GUI 点击“创建任务”时可能重新拉起一个程序窗口的问题。
+- GUI 入口现在会在 Qt 初始化前调用 `multiprocessing.freeze_support()`，避免 PyInstaller 打包后的子进程把 GUI 入口当作新主进程执行。
+- 新增 GUI 单例守护，二次启动会激活已有窗口，减少重复窗口和重复任务队列的风险。
+
+### 修复后台数据未就绪时仍可创建任务
+
+- 执行页现在会接入共享数据加载状态，后台数据准备中会禁用或拦截“创建任务”。
+- 按钮 tooltip 和页面提示会说明当前正在准备后台数据，避免用户误以为按钮失效。
+- 后台数据失败时不会把页面永久锁死，用户仍可看到错误并通过刷新数据重新恢复。
+
+### 修复地图解包缺少数据时静默无输出
+
+- 地图任务在执行前会校验 map banks 基础数据是否已经准备完成。
+- 缺少地图数据时会直接给出明确错误，避免队列显示已启动但没有任何可见输出。
+- 该校验同时覆盖解包和映射任务，减少地图数据缺失导致的后续误判。
+
+### 修复打包版 metadata 版本提示
+
+- 修复打包版生成 metadata 时可能提示“无法获取包版本，请使用安装或编辑模式安装”的问题。
+- `scriptVersion` 现在会优先读取 PyInstaller 注入的 `LOL_AUDIO_UNPACK_BUILD_VERSION`，再回退到运行时版本和包 metadata。
+- 正常打包运行时不再因为缺少 Python package distribution metadata 而回退为开发占位版本。
+
+### 统一 GUI 项目配置位置
+
+- 项目自有 GUI 配置统一写入运行目录下的 `config/lol-audio-unpack.ini`。
+- GUI 偏好写入 `[gui]`，新手引导状态写入 `[onboarding]`，后续排查和重置更明确。
+- 默认输出目录仍保持为运行目录下的 `output/`，不会因为配置目录统一而改变。
+- QFluentWidgets 框架自身的 `config/config.json` 继续独立保留，不混入项目 INI。
+
+### 增加装备查询失败日志
+
+- 装备查询页面加载失败时，现在会写入 `装备数据加载失败: ...` 错误日志。
+- 该日志用于区分网络、代理、TLS、超时、腾讯官网临时异常或数据格式变化等问题。
+- 页面仍保留刷新按钮，失败只影响装备查询页面，不影响音频解包流程。
+
+## 兼容性说明
+
+- 本版本不迁移旧版用户全局 QSettings 和旧程序根目录 INI。由于此前打包版存在阻断正常解包的问题，本版本按新的 `config/` 目录规则重新开始。
+- 已经手动调整过的 GUI 偏好可能需要在新版中重新设置一次，包括试听音量、日志等级、主题偏好和首次引导状态。
+- 本版本不修改 CLI 参数、音频输出目录结构、WEM 原始产物规则或事件映射输出格式。
+
+## 验证
+
+- `uv run pytest tests/gui/test_execution_page.py tests/gui/test_window_shell_controller.py tests/gui/test_task_runner.py tests/gui/test_execution_queue_controller.py tests/gui/test_execution_process_worker.py tests/test_pyinstaller_packaging.py tests/gui/test_single_instance.py tests/runtime/test_runtime_paths.py tests/config/test_config_package_api.py tests/app/test_app_context.py tests/gui/test_gui_config.py tests/gui/test_gui_config_onboarding.py tests/gui/test_setting_page_theme_preset.py tests/manager/test_manager_utils.py tests/test_test_runtime_policy.py tests/gui/test_item_catalog.py tests/gui/test_item_lookup_grid.py tests/gui/test_item_lookup_page.py -q` 通过，`149 passed`。
+- `uv run ruff check` 覆盖本次 GUI、配置、运行时路径、版本解析和测试改动，已通过。
+- 本地 PyInstaller GUI 打包验证通过，生成 `.temp/pyinstaller/dist/LolAudioUnpack.exe`。
+
+## 发布范围
+
+- 基线：`v3.7.1`
+- 主要覆盖：
+  - `fix(gui): 修复打包启动与数据准备流程`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lol-audio-unpack"
-version = "3.7.1"
+version = "3.7.2"
 description = "英雄联盟游戏音频文件解包工具"
 authors = [
     { name = "Virace", email = "Virace@aliyun.com" }

--- a/src/lol_audio_unpack/__init__.py
+++ b/src/lol_audio_unpack/__init__.py
@@ -15,7 +15,7 @@ from .utils.versioning import resolve_runtime_version
 if TYPE_CHECKING:
     from .app import AppContext
 
-_STATIC_VERSION = "3.7.1"
+_STATIC_VERSION = "3.7.2"
 __version__ = resolve_runtime_version(Path(__file__).resolve().parents[2], _STATIC_VERSION)
 
 logger.disable("lol_audio_unpack")

--- a/src/lol_audio_unpack/config/__init__.py
+++ b/src/lol_audio_unpack/config/__init__.py
@@ -7,10 +7,12 @@ from .ini import (
     DEFAULT_CONFIG_FILENAME,
     DEFAULT_DEV_CONFIG_FILENAME,
     load_command_config,
+    load_section,
     load_settings,
     remove_command_config_keys,
     resolve_default_path,
     write_command_config,
+    write_section,
     write_settings,
 )
 from .schema import (
@@ -49,9 +51,11 @@ __all__ = [
     "SharedSettingField",
     "build_settings",
     "load_command_config",
+    "load_section",
     "load_settings",
     "remove_command_config_keys",
     "resolve_default_path",
     "write_command_config",
+    "write_section",
     "write_settings",
 ]

--- a/src/lol_audio_unpack/config/ini.py
+++ b/src/lol_audio_unpack/config/ini.py
@@ -197,6 +197,46 @@ def remove_command_config_keys(
         parser.write(handle)
 
 
+def load_section(
+    config_file: StrPath,
+    *,
+    section: str,
+    require_exists: bool = True,
+) -> dict[str, str]:
+    """读取指定 INI section 的原始键值。"""
+    parser = _load_config_parser(config_file, require_exists=require_exists)
+    if parser is None or not parser.has_section(section):
+        return {}
+    return {key: value.strip() for key, value in parser.items(section)}
+
+
+def write_section(
+    config_file: StrPath,
+    *,
+    section: str,
+    values: dict[str, Any],
+) -> None:
+    """写入指定 INI section 的原始键值，并保留其他 section。"""
+    config_path, parser = _ensure_parser(config_file)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not parser.has_section(section):
+        parser.add_section(section)
+    target = parser[section]
+
+    for key, value in values.items():
+        if value is None:
+            target.pop(key, None)
+            continue
+        target[key] = str(value).lower() if isinstance(value, bool) else str(value)
+
+    if not list(target.items()):
+        parser.remove_section(section)
+
+    with config_path.open("w", encoding="utf-8") as handle:
+        parser.write(handle)
+
+
 def _parse_command_value(
     section: configparser.SectionProxy,
     *,
@@ -240,9 +280,11 @@ __all__ = [
     "DEFAULT_CONFIG_FILENAME",
     "DEFAULT_DEV_CONFIG_FILENAME",
     "load_command_config",
+    "load_section",
     "load_settings",
     "remove_command_config_keys",
     "resolve_default_path",
     "write_command_config",
+    "write_section",
     "write_settings",
 ]

--- a/src/lol_audio_unpack/config/schema.py
+++ b/src/lol_audio_unpack/config/schema.py
@@ -45,6 +45,8 @@ class ConfigSection:
     EXTRACT = "extract"
     WAV = "wav"
     MAPPING = "mapping"
+    GUI = "gui"
+    ONBOARDING = "onboarding"
 
 
 DEFAULT_REMOTE_LIVE_REGION = "EUW"

--- a/src/lol_audio_unpack/gui/__main__.py
+++ b/src/lol_audio_unpack/gui/__main__.py
@@ -1,9 +1,15 @@
 """GUI 应用入口。"""
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
+import multiprocessing
 import sys
 from time import perf_counter
+
+# PyInstaller 冻结态的 multiprocessing 子进程必须在导入 Qt 前完成分流。
+multiprocessing.freeze_support()
 
 from loguru import logger
 from PySide6.QtCore import Qt
@@ -21,6 +27,7 @@ from lol_audio_unpack.gui.controllers.contracts import RuntimeLoggingConfig
 from lol_audio_unpack.gui.controllers.runtime_logging_session import (
     apply_runtime_logging_session,
 )
+from lol_audio_unpack.gui.single_instance import acquire_or_activate
 from lol_audio_unpack.gui.theme import apply_accent_preset, apply_shell_mode
 from lol_audio_unpack.gui.window import MainWindow
 
@@ -74,6 +81,11 @@ def main() -> None:
 
     app = QApplication(sys.argv)
     previous_mark = _log_startup_stage("QApplication 创建完成", startup_begin, previous_mark)
+    instance_guard = acquire_or_activate(parent=app)
+    if instance_guard is None:
+        logger.info("已有 GUI 实例正在运行，已发送窗口激活请求。")
+        return
+    previous_mark = _log_startup_stage("单实例守卫初始化完成", startup_begin, previous_mark)
 
     # 彻底解决 Windows 下中文 HighDPI 渲染 "横线发虚/掉底" 问题
     font = QFont("Microsoft YaHei")
@@ -93,6 +105,7 @@ def main() -> None:
 
     # 获取桌面并应用大小
     window = MainWindow()
+    instance_guard.set_window(window)
     remove_startup_log_buffer()
     previous_mark = _log_startup_stage("MainWindow 构建完成", startup_begin, previous_mark)
     if not window.isVisible():

--- a/src/lol_audio_unpack/gui/common/gui_config.py
+++ b/src/lol_audio_unpack/gui/common/gui_config.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6.QtCore import QSettings
-
 from lol_audio_unpack.config import (
     DEFAULT_REMOTE_LIVE_REGION,
     ConfigSection,
     SettingKey,
     load_command_config,
+    load_section,
     load_settings,
     remove_command_config_keys,
     resolve_default_path,
     write_command_config,
+    write_section,
     write_settings,
 )
 from lol_audio_unpack.gui.common.remote_mode_policy import resolve_source_mode
@@ -35,9 +35,8 @@ from lol_audio_unpack.utils.runtime_paths import (
 # Sentinel
 # ---------------------------------------------------------------------------
 
-_UNSET = object()  # distinguishes "not in file" from ""
-_ONBOARDING_COMPLETED_KEY = "onboarding/completed_version"
-_ONBOARDING_SKIPPED_KEY = "onboarding/skipped_version"
+_ONBOARDING_COMPLETED_KEY = "completed_version"
+_ONBOARDING_SKIPPED_KEY = "skipped_version"
 
 
 class GuiConfig:
@@ -49,9 +48,6 @@ class GuiConfig:
 
         self._dev_mode = dev_mode
         self._config_file = resolve_default_path(dev_mode=dev_mode)
-
-        # QSettings 用于 GUI 独有配置
-        self._qs = QSettings(QSettings.Format.IniFormat, QSettings.Scope.UserScope, "ViraceLab", "LolAudioUnpack")
 
         # 内部缓存 — CLI 共享配置
         self._source_mode: str = "local_path"
@@ -86,16 +82,25 @@ class GuiConfig:
         self._preview_audio_output_device_key: str = "default"
 
     def load(self) -> None:
-        """从标准 INI 和 QSettings 加载配置。"""
+        """从项目标准 INI 加载配置。"""
         shared_settings = load_settings(self._config_file, require_exists=False)
         wav_settings = load_command_config(
             self._config_file,
             command=ConfigSection.WAV,
             require_exists=False,
         )
+        gui_settings = load_section(
+            self._config_file,
+            section=ConfigSection.GUI,
+            require_exists=False,
+        )
 
         def _shared_value(key: str, default: str) -> str:
             file_value = shared_settings.get(key)
+            return default if file_value is None else str(file_value)
+
+        def _gui_value(key: str, default: str) -> str:
+            file_value = gui_settings.get(key)
             return default if file_value is None else str(file_value)
 
         # 1. 读取共享配置
@@ -116,71 +121,40 @@ class GuiConfig:
         self._wav_retries = int(wav_settings.get("wav_retries", 3))
         self._wav_format = str(wav_settings.get("wav_format", "pcm16") or "pcm16")
 
-        # 2. GUI 专有配置只走 QSettings
-        stored_vgmstream_path = self._qs.value("vgmstream_path", _UNSET)
-        if stored_vgmstream_path is _UNSET:
-            self._vgmstream_path = ""
-        else:
-            self._vgmstream_path = str(stored_vgmstream_path or "")
+        # 2. GUI 专有配置统一走项目 INI，不再读取用户全局 QSettings。
+        self._vgmstream_path = _gui_value("vgmstream_path", "")
 
         inferred_snapshot_strategy = (
             "custom"
             if self._snapshot_version and self._snapshot_lcu_url and self._snapshot_game_url
             else "latest"
         )
-        self._remote_snapshot_strategy = str(
-            self._qs.value("remote_snapshot_strategy", inferred_snapshot_strategy) or inferred_snapshot_strategy
+        self._remote_snapshot_strategy = (
+            _gui_value("remote_snapshot_strategy", inferred_snapshot_strategy) or inferred_snapshot_strategy
         )
-        stored_snapshot_version = self._qs.value("remote_snapshot_version", _UNSET)
-        if stored_snapshot_version is not _UNSET:
-            self._snapshot_version = str(stored_snapshot_version or "")
-        stored_snapshot_lcu_url = self._qs.value("remote_snapshot_lcu_url", _UNSET)
-        if stored_snapshot_lcu_url is not _UNSET:
-            self._snapshot_lcu_url = str(stored_snapshot_lcu_url or "")
-        stored_snapshot_game_url = self._qs.value("remote_snapshot_game_url", _UNSET)
-        if stored_snapshot_game_url is not _UNSET:
-            self._snapshot_game_url = str(stored_snapshot_game_url or "")
+        self.remote_snapshot_strategy = self._remote_snapshot_strategy
+        self._snapshot_version = _gui_value("remote_snapshot_version", self._snapshot_version)
+        self._snapshot_lcu_url = _gui_value("remote_snapshot_lcu_url", self._snapshot_lcu_url)
+        self._snapshot_game_url = _gui_value("remote_snapshot_game_url", self._snapshot_game_url)
 
-        # 3. 从 QSettings 读取 GUI 主题配置
-        self._theme_mode = str(self._qs.value("theme_mode", "Auto") or "Auto")
-        stored_accent_preset = self._qs.value("accent_preset_id", _UNSET)
-        stored_theme_color = str(self._qs.value("theme_color", self._theme_color) or self._theme_color)
-        if stored_accent_preset is _UNSET:
-            self._accent_preset_id = resolve_legacy_accent_preset(stored_theme_color)
-        else:
-            self._accent_preset_id = resolve_accent_preset_id(str(stored_accent_preset))
+        self._theme_mode = _gui_value("theme_mode", "Auto") or "Auto"
+        self._accent_preset_id = resolve_accent_preset_id(_gui_value("accent_preset_id", self._accent_preset_id))
         self._theme_color = get_accent_preset(self._accent_preset_id).primary_hex
 
-        legacy_smooth_scroll = self._qs.value("smooth_scroll_enabled", _UNSET)
-        stored_page_smooth_scroll = self._qs.value("page_smooth_scroll_enabled", _UNSET)
-        stored_widget_smooth_scroll = self._qs.value("widget_smooth_scroll_enabled", _UNSET)
-        legacy_smooth_scroll_enabled = (
-            False if legacy_smooth_scroll is _UNSET else self._to_bool(legacy_smooth_scroll)
-        )
-        self._page_smooth_scroll_enabled = (
-            legacy_smooth_scroll_enabled
-            if stored_page_smooth_scroll is _UNSET
-            else self._to_bool(stored_page_smooth_scroll)
-        )
-        self._widget_smooth_scroll_enabled = (
-            legacy_smooth_scroll_enabled
-            if stored_widget_smooth_scroll is _UNSET
-            else self._to_bool(stored_widget_smooth_scroll)
-        )
+        self._page_smooth_scroll_enabled = self._to_bool(_gui_value("page_smooth_scroll_enabled", "false"))
+        self._widget_smooth_scroll_enabled = self._to_bool(_gui_value("widget_smooth_scroll_enabled", "false"))
         self._log_drawer_auto_collapse_enabled = self._to_bool(
-            self._qs.value("log_drawer_auto_collapse_enabled", True)
+            _gui_value("log_drawer_auto_collapse_enabled", "true")
         )
-        self._console_log_level = str(self._qs.value("console_log_level", "INFO") or "INFO").upper()
-        self._file_log_level = str(self._qs.value("file_log_level", "DEBUG") or "DEBUG").upper()
+        self._console_log_level = _gui_value("console_log_level", "INFO").upper()
+        self._file_log_level = _gui_value("file_log_level", "DEBUG").upper()
         self._preview_audio_volume_percent = self._clamp_percentage(
-            self._qs.value("preview_audio_volume_percent", 10)
+            _gui_value("preview_audio_volume_percent", "10")
         )
-        self._preview_audio_output_device_key = str(
-            self._qs.value("preview_audio_output_device_key", "default") or "default"
-        )
+        self.preview_audio_output_device_key = _gui_value("preview_audio_output_device_key", "default")
 
     def save(self) -> None:
-        """保存配置到标准 INI 与 QSettings。"""
+        """保存配置到项目标准 INI。"""
         snapshot_overrides = self._snapshot_overrides()
         write_settings(
             self._config_file,
@@ -215,27 +189,18 @@ class GuiConfig:
             ini_keys=("wav",),
         )
 
-        # 保存 GUI 专有配置到 QSettings
-        self._qs.setValue("vgmstream_path", self._vgmstream_path)
-        self._qs.setValue("remote_snapshot_strategy", self._remote_snapshot_strategy)
-        self._qs.setValue("remote_snapshot_version", self._snapshot_version)
-        self._qs.setValue("remote_snapshot_lcu_url", self._snapshot_lcu_url)
-        self._qs.setValue("remote_snapshot_game_url", self._snapshot_game_url)
-        self._qs.setValue("theme_mode", self._theme_mode)
-        self._qs.setValue("accent_preset_id", self._accent_preset_id)
-        self._qs.setValue("page_smooth_scroll_enabled", self._page_smooth_scroll_enabled)
-        self._qs.setValue("widget_smooth_scroll_enabled", self._widget_smooth_scroll_enabled)
-        self._qs.setValue("log_drawer_auto_collapse_enabled", self._log_drawer_auto_collapse_enabled)
-        self._qs.setValue("console_log_level", self._console_log_level)
-        self._qs.setValue("file_log_level", self._file_log_level)
-        self._qs.setValue("preview_audio_volume_percent", self._preview_audio_volume_percent)
-        self._qs.setValue("preview_audio_output_device_key", self._preview_audio_output_device_key)
-        self._qs.setValue("smooth_scroll_enabled", self.smooth_scroll_enabled)
+        self._write_gui_section()
 
     def save_theme_preferences(self) -> None:
         """仅保存主题相关的 GUI 偏好，不触碰共享 runtime 配置。"""
-        self._qs.setValue("theme_mode", self._theme_mode)
-        self._qs.setValue("accent_preset_id", self._accent_preset_id)
+        write_section(
+            self._config_file,
+            section=ConfigSection.GUI,
+            values={
+                "theme_mode": self._theme_mode,
+                "accent_preset_id": self._accent_preset_id,
+            },
+        )
 
     def to_app_context_settings(self) -> dict[str, str | bool]:
         """构建供 ``create_app_context`` 使用的共享配置映射。"""
@@ -314,8 +279,9 @@ class GuiConfig:
         version = str(guide_version or "").strip()
         if not version:
             return False
-        completed = str(self._qs.value(_ONBOARDING_COMPLETED_KEY, "") or "")
-        skipped = str(self._qs.value(_ONBOARDING_SKIPPED_KEY, "") or "")
+        state = self._load_onboarding_state()
+        completed = state.get(_ONBOARDING_COMPLETED_KEY, "")
+        skipped = state.get(_ONBOARDING_SKIPPED_KEY, "")
         return version not in (completed, skipped)
 
     def mark_onboarding_completed(self, guide_version: str) -> None:
@@ -327,7 +293,7 @@ class GuiConfig:
 
         version = str(guide_version or "").strip()
         if version:
-            self._qs.setValue(_ONBOARDING_COMPLETED_KEY, version)
+            self._write_onboarding_state(completed=version)
 
     def mark_onboarding_skipped(self, guide_version: str) -> None:
         """记录当前引导版本已经跳过。
@@ -338,7 +304,7 @@ class GuiConfig:
 
         version = str(guide_version or "").strip()
         if version:
-            self._qs.setValue(_ONBOARDING_SKIPPED_KEY, version)
+            self._write_onboarding_state(skipped=version)
 
     def reset_onboarding(self, guide_version: str) -> None:
         """清除当前引导版本的完成与跳过状态。
@@ -351,10 +317,14 @@ class GuiConfig:
         if not version:
             return
 
-        if str(self._qs.value(_ONBOARDING_COMPLETED_KEY, "") or "") == version:
-            self._qs.setValue(_ONBOARDING_COMPLETED_KEY, "")
-        if str(self._qs.value(_ONBOARDING_SKIPPED_KEY, "") or "") == version:
-            self._qs.setValue(_ONBOARDING_SKIPPED_KEY, "")
+        state = self._load_onboarding_state()
+        completed = (
+            ""
+            if state.get(_ONBOARDING_COMPLETED_KEY, "") == version
+            else state.get(_ONBOARDING_COMPLETED_KEY, "")
+        )
+        skipped = "" if state.get(_ONBOARDING_SKIPPED_KEY, "") == version else state.get(_ONBOARDING_SKIPPED_KEY, "")
+        self._write_onboarding_state(completed=completed, skipped=skipped)
 
     # ------------------------------------------------------------------
     # Properties — source
@@ -666,6 +636,59 @@ class GuiConfig:
         except (TypeError, ValueError):
             normalized = 10
         return max(0, min(100, normalized))
+
+    def _write_gui_section(self) -> None:
+        """将 GUI 专有状态写入项目 INI 的 ``gui`` 分组。"""
+        write_section(
+            self._config_file,
+            section=ConfigSection.GUI,
+            values={
+                "vgmstream_path": self._vgmstream_path,
+                "remote_snapshot_strategy": self._remote_snapshot_strategy,
+                "remote_snapshot_version": self._snapshot_version,
+                "remote_snapshot_lcu_url": self._snapshot_lcu_url,
+                "remote_snapshot_game_url": self._snapshot_game_url,
+                "theme_mode": self._theme_mode,
+                "accent_preset_id": self._accent_preset_id,
+                "page_smooth_scroll_enabled": self._page_smooth_scroll_enabled,
+                "widget_smooth_scroll_enabled": self._widget_smooth_scroll_enabled,
+                "log_drawer_auto_collapse_enabled": self._log_drawer_auto_collapse_enabled,
+                "console_log_level": self._console_log_level,
+                "file_log_level": self._file_log_level,
+                "preview_audio_volume_percent": self._preview_audio_volume_percent,
+                "preview_audio_output_device_key": self._preview_audio_output_device_key,
+            },
+        )
+
+    def _load_onboarding_state(self) -> dict[str, str]:
+        """读取项目 INI 中的新手引导状态。"""
+        return load_section(
+            self._config_file,
+            section=ConfigSection.ONBOARDING,
+            require_exists=False,
+        )
+
+    def _write_onboarding_state(
+        self,
+        *,
+        completed: str | None = None,
+        skipped: str | None = None,
+    ) -> None:
+        """写入新手引导状态，并保留未显式更新的字段。"""
+        state = self._load_onboarding_state()
+        if completed is not None:
+            state[_ONBOARDING_COMPLETED_KEY] = completed
+        if skipped is not None:
+            state[_ONBOARDING_SKIPPED_KEY] = skipped
+
+        write_section(
+            self._config_file,
+            section=ConfigSection.ONBOARDING,
+            values={
+                _ONBOARDING_COMPLETED_KEY: state.get(_ONBOARDING_COMPLETED_KEY, ""),
+                _ONBOARDING_SKIPPED_KEY: state.get(_ONBOARDING_SKIPPED_KEY, ""),
+            },
+        )
 
     def _snapshot_overrides(self) -> dict[str, str]:
         """根据当前远端快照策略构建实际生效的快照覆盖项。"""

--- a/src/lol_audio_unpack/gui/controllers/window_shell.py
+++ b/src/lol_audio_unpack/gui/controllers/window_shell.py
@@ -197,6 +197,7 @@ def bind_shared_data_controller_signals(  # noqa: PLR0913
     controller.loading_state_changed.connect(
         lambda state: home_page.set_loading_state(state.message, active=state.active)
     )
+    controller.loading_state_changed.connect(execution_page.set_shared_data_loading_state)
     controller.shared_data_cleared.connect(execution_page.clear_entity_data)
     controller.shared_data_cleared.connect(overview_page.clear_data)
     controller.app_context_changed.connect(overview_page.set_app_context)

--- a/src/lol_audio_unpack/gui/service/task_runner.py
+++ b/src/lol_audio_unpack/gui/service/task_runner.py
@@ -18,6 +18,7 @@ from lol_audio_unpack.gui.task_models import (
     ExecutionTaskResult,
     QueuedExecutionTask,
 )
+from lol_audio_unpack.manager import DataReader
 
 if TYPE_CHECKING:
     from lol_audio_unpack.gui.workers import WorkerSignals
@@ -113,6 +114,44 @@ def _emit_stage_progress(  # noqa: PLR0913
     )
 
 
+def _ensure_map_banks_ready(
+    runtime_app: LolAudioUnpackApp,
+    task: QueuedExecutionTask,
+    *,
+    include_maps: bool,
+) -> None:
+    """在执行地图任务前确认地图 banks 已完成生成。
+
+    Args:
+        runtime_app: 当前任务使用的运行时门面。
+        task: 已入队任务。
+        include_maps: 当前任务范围是否包含地图。
+
+    Raises:
+        RuntimeError: 地图基础 banks 缺失时抛出，避免静默跳过地图输出。
+    """
+    if not include_maps:
+        return
+
+    ctx = getattr(runtime_app, "ctx", None)
+    if ctx is None:
+        return
+
+    reader = DataReader(ctx=ctx)
+    map_ids = task.draft.task_params.map_ids
+    target_ids = tuple(int(map_id) for map_id in map_ids) if map_ids is not None else tuple(
+        int(map_data["id"]) for map_data in reader.get_maps() if map_data.get("id") is not None
+    )
+    missing_ids = [map_id for map_id in target_ids if not reader.get_map_banks(map_id)]
+    if not missing_ids:
+        return
+
+    raise RuntimeError(
+        "地图基础数据仍未准备完成，缺少地图 banks: "
+        f"{missing_ids[:10]}。请等待后台数据准备完成后再创建任务。"
+    )
+
+
 def run_execution_task(task: QueuedExecutionTask, signals: WorkerSignals) -> ExecutionTaskResult:
     """在后台线程中执行单个队列任务。
 
@@ -137,6 +176,7 @@ def run_execution_task(task: QueuedExecutionTask, signals: WorkerSignals) -> Exe
     steps = task_params.selected_steps()
     completed_steps: list[str] = []
     runtime_app: LolAudioUnpackApp | None = None
+    map_banks_checked = False
     runtime_settings = _build_runtime_settings(task)
     source_mode = runtime_settings.get(SettingKey.SOURCE_MODE, "local_path")
 
@@ -201,6 +241,9 @@ def run_execution_task(task: QueuedExecutionTask, signals: WorkerSignals) -> Exe
                             settings=runtime_settings,
                         )
                     )
+                if not map_banks_checked:
+                    _ensure_map_banks_ready(runtime_app, task, include_maps=include_maps)
+                    map_banks_checked = True
 
                 _emit_stage_progress(
                     signals,
@@ -299,6 +342,9 @@ def run_execution_task(task: QueuedExecutionTask, signals: WorkerSignals) -> Exe
                             settings=runtime_settings,
                         )
                     )
+                if not map_banks_checked:
+                    _ensure_map_banks_ready(runtime_app, task, include_maps=include_maps)
+                    map_banks_checked = True
 
                 _emit_stage_progress(
                     signals,

--- a/src/lol_audio_unpack/gui/single_instance.py
+++ b/src/lol_audio_unpack/gui/single_instance.py
@@ -1,0 +1,121 @@
+"""GUI 单实例运行守卫。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtNetwork import QLocalServer, QLocalSocket
+
+INSTANCE_KEY = "Virace-LolAudioUnpack-GUI"
+ACTIVATE_MESSAGE = b"activate"
+DEFAULT_TIMEOUT_MS = 300
+
+
+def activate_window(window: Any) -> None:
+    """将已有 GUI 主窗口恢复到前台。
+
+    Args:
+        window: 需要恢复和激活的 Qt 窗口对象。
+    """
+    if window is None:
+        return
+    if not window.isVisible():
+        window.show()
+    elif window.isMinimized():
+        window.showNormal()
+    window.raise_()
+    window.activateWindow()
+
+
+class SingleInstanceGuard(QObject):
+    """持有本地服务名，并在收到二次启动请求时激活主窗口。"""
+
+    activated = Signal()
+
+    def __init__(self, server: QLocalServer | None, parent: QObject | None = None) -> None:
+        """初始化单实例守卫。
+
+        Args:
+            server: 已成功监听的本地服务；为 ``None`` 时退化为无守卫模式。
+            parent: Qt 父对象。
+        """
+        super().__init__(parent)
+        self._server = server
+        self._window: Any = None
+        if self._server is not None:
+            self._server.newConnection.connect(self._handle_new_connection)
+        self.activated.connect(lambda: activate_window(self._window))
+
+    def set_window(self, window: Any) -> None:
+        """绑定需要被二次启动请求激活的主窗口。
+
+        Args:
+            window: 当前进程创建的主窗口对象。
+        """
+        self._window = window
+
+    def _handle_new_connection(self) -> None:
+        """消费二次启动连接，并触发窗口激活。"""
+        if self._server is not None:
+            while self._server.hasPendingConnections():
+                socket = self._server.nextPendingConnection()
+                if socket is not None:
+                    socket.readAll()
+                    socket.disconnectFromServer()
+        self.activated.emit()
+
+
+def _send_activation_request(
+    *,
+    key: str,
+    socket_cls: type[QLocalSocket],
+    timeout_ms: int,
+) -> bool:
+    """向已有 GUI 实例发送激活请求。"""
+    socket = socket_cls()
+    socket.connectToServer(key)
+    if not socket.waitForConnected(timeout_ms):
+        return False
+    socket.write(ACTIVATE_MESSAGE)
+    socket.flush()
+    socket.waitForBytesWritten(timeout_ms)
+    socket.disconnectFromServer()
+    return True
+
+
+def acquire_or_activate(
+    *,
+    key: str = INSTANCE_KEY,
+    parent: QObject | None = None,
+    server_cls: type[QLocalServer] = QLocalServer,
+    socket_cls: type[QLocalSocket] = QLocalSocket,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
+) -> SingleInstanceGuard | None:
+    """获取 GUI 单实例守卫，或激活已有实例后返回 ``None``。
+
+    Args:
+        key: 本地服务名。
+        parent: Qt 父对象。
+        server_cls: 本地服务类，测试中可替换。
+        socket_cls: 本地 socket 类，测试中可替换。
+        timeout_ms: 连接已有实例时的超时时间。
+
+    Returns:
+        新进程应继续启动时返回守卫；已有实例已被激活时返回 ``None``。
+    """
+    server = server_cls(parent)
+    if server.listen(key):
+        return SingleInstanceGuard(server, parent=parent)
+
+    if _send_activation_request(key=key, socket_cls=socket_cls, timeout_ms=timeout_ms):
+        return None
+
+    server_cls.removeServer(key)
+    server = server_cls(parent)
+    if server.listen(key):
+        return SingleInstanceGuard(server, parent=parent)
+
+    logger.warning("[GUI] 单实例服务监听失败，当前进程将继续以无守卫模式启动。")
+    return SingleInstanceGuard(None, parent=parent)

--- a/src/lol_audio_unpack/gui/view/execution_page.py
+++ b/src/lol_audio_unpack/gui/view/execution_page.py
@@ -28,7 +28,7 @@ from lol_audio_unpack.gui.controllers import (
     ExecutionQueueController,
     ExecutionSelectionController,
 )
-from lol_audio_unpack.gui.controllers.contracts import OverviewSelectionSyncRequest
+from lol_audio_unpack.gui.controllers.contracts import OverviewSelectionSyncRequest, SharedDataLoadingState
 from lol_audio_unpack.gui.controllers.entity_data_store import EntityDataStore
 from lol_audio_unpack.gui.task_models import ExecutionTaskResult, QueuedExecutionTask
 from lol_audio_unpack.gui.view.execution.progress_state import (
@@ -64,6 +64,8 @@ class ExecutionPage(SmoothScrollArea):
         self._entity_data_store = EntityDataStore(entity_types=("champions", "maps"))
         self._is_task_running = False
         self._is_task_queue_busy = False
+        self._shared_data_busy_message = ""
+        self._shared_data_block_reason = ""
         self._current_global_progress_state = GlobalProgressStripState()
         self._selection_controller = ExecutionSelectionController()
         self._log_controller = ExecutionLogController(
@@ -179,6 +181,21 @@ class ExecutionPage(SmoothScrollArea):
     def clear_entity_data(self) -> None:
         """清空当前已加载实体目录摘要。"""
         self._entity_data_store.clear()
+
+    def set_shared_data_loading_state(self, state: SharedDataLoadingState) -> None:
+        """同步共享数据加载状态到任务创建门禁。"""
+        message = str(state.message or "")
+        if state.active:
+            self._shared_data_busy_message = message
+            self._shared_data_block_reason = ""
+        else:
+            self._shared_data_busy_message = ""
+            self._shared_data_block_reason = (
+                f"共享数据暂不可用：{message}"
+                if message and message != "实体数据已就绪"
+                else ""
+            )
+        self._sync_primary_action_button()
 
     def attach_runtime_log_sink(self, level: str = "INFO") -> None:
         """重新挂载 GUI 运行时日志 sink。"""
@@ -336,7 +353,18 @@ class ExecutionPage(SmoothScrollArea):
 
     def _sync_primary_action_button(self) -> None:
         """根据当前运行态切换主按钮文案。"""
-        self.create_task_btn.setText("取消" if self._is_task_running else "创建任务")
+        if self._is_task_running:
+            self.create_task_btn.setText("取消")
+            self.create_task_btn.setToolTip("取消当前运行中的任务。")
+            return
+        if self._shared_data_busy_message:
+            self.create_task_btn.setText("准备数据中")
+            self.create_task_btn.setToolTip(
+                f"后台数据准备中：{self._shared_data_busy_message} 完成后才能创建任务。"
+            )
+            return
+        self.create_task_btn.setText("创建任务")
+        self.create_task_btn.setToolTip(self._shared_data_block_reason)
 
     def _handle_primary_task_action(self) -> None:
         """根据当前运行态分派创建或取消行为。"""
@@ -370,6 +398,29 @@ class ExecutionPage(SmoothScrollArea):
 
     def _queue_task_draft(self) -> None:
         """将当前界面参数写入任务队列，并自动开始首个任务。"""
+        if self._shared_data_busy_message:
+            message = f"后台数据仍在准备：{self._shared_data_busy_message}，完成后再创建任务。"
+            self._log_gui_event("warning", f"[队列] {message}")
+            show_feedback_infobar(
+                title="后台数据准备中",
+                content=message,
+                parent=self._feedback_parent(),
+                level="warning",
+                position=InfoBarPosition.TOP,
+            )
+            return
+
+        if self._shared_data_block_reason:
+            self._log_gui_event("warning", f"[队列] {self._shared_data_block_reason}")
+            show_feedback_infobar(
+                title="无法创建任务",
+                content=self._shared_data_block_reason,
+                parent=self._feedback_parent(),
+                level="warning",
+                position=InfoBarPosition.TOP,
+            )
+            return
+
         task_scope_summary = self.taskBuilderPanel.selected_task_scope_summary()
         if task_scope_summary == "未选择执行内容":
             self._log_gui_event("warning", "[队列] 未勾选任何执行步骤，已阻止创建任务。")

--- a/src/lol_audio_unpack/gui/view/item_lookup_page.py
+++ b/src/lol_audio_unpack/gui/view/item_lookup_page.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from loguru import logger
 from PySide6.QtCore import Qt, QThreadPool, QTimer
 from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import QApplication, QHBoxLayout, QSizePolicy, QVBoxLayout, QWidget
@@ -207,6 +208,7 @@ class ItemLookupPage(QWidget):
 
     def _on_load_failed(self, message: str) -> None:
         """显示加载失败状态，等待用户手动刷新。"""
+        logger.error(f"装备数据加载失败: {message}")
         self._is_loading = False
         self._active_worker = None
         self.refresh_button.setEnabled(True)

--- a/src/lol_audio_unpack/manager/utils.py
+++ b/src/lol_audio_unpack/manager/utils.py
@@ -10,6 +10,7 @@ from importlib.metadata import version as get_package_version
 
 from loguru import logger
 
+import lol_audio_unpack
 from lol_audio_unpack.app.game_version import (
     get_game_version,
     get_lcu_version,
@@ -17,6 +18,24 @@ from lol_audio_unpack.app.game_version import (
     validate_install_version,
 )
 from lol_audio_unpack.manager.files import find_data_file, needs_update, read_data, write_data
+from lol_audio_unpack.utils.versioning import BUILD_VERSION_ENV
+
+
+def _resolve_script_version() -> str:
+    """按运行环境解析 metadata 使用的脚本版本。"""
+    injected_version = os.getenv(BUILD_VERSION_ENV, "").strip()
+    if injected_version:
+        return injected_version
+
+    __version__ = getattr(lol_audio_unpack, "__version__", "")
+    if str(__version__).strip():
+        return str(__version__).strip()
+
+    try:
+        return get_package_version("lol-audio-unpack")
+    except PackageNotFoundError:
+        logger.debug("无法获取包版本，metadata scriptVersion 回退到 '0.0.0-dev'。")
+        return "0.0.0-dev"
 
 
 def build_metadata_payload(game_version: str, languages: list[str]) -> dict:
@@ -29,11 +48,7 @@ def build_metadata_payload(game_version: str, languages: list[str]) -> dict:
     Returns:
         一个包含所有元数据的字典。
     """
-    try:
-        script_version = get_package_version("lol-audio-unpack")
-    except PackageNotFoundError:
-        script_version = "0.0.0-dev"
-        logger.warning("无法获取包版本，请使用 'pip install -e .' 在可编辑模式下安装。将版本设置为 '0.0.0-dev'。")
+    script_version = _resolve_script_version()
 
     metadata = {
         "gameVersion": game_version,

--- a/src/lol_audio_unpack/utils/runtime_paths.py
+++ b/src/lol_audio_unpack/utils/runtime_paths.py
@@ -76,7 +76,7 @@ def detect_runtime_paths(
         is_frozen=frozen,
         executable_path=executable_path,
         launch_root=launch_root,
-        config_root=launch_root,
+        config_root=launch_root / "config",
         bundle_root=launch_root,
     )
 

--- a/tests/app/test_app_context.py
+++ b/tests/app/test_app_context.py
@@ -296,7 +296,8 @@ def test_load_command_config_reads_runtime_and_wav_sections(tmp_path: Path) -> N
 def test_resolve_default_path_uses_runtime_config_root() -> None:
     config_file = resolve_default_path()
     assert config_file.name == "lol-audio-unpack.ini"
-    assert config_file.parent.name == "isolated_env"
+    assert config_file.parent.name == "config"
+    assert config_file.parent.parent.name == "isolated_env"
 
 
 def test_write_settings_creates_expected_section(tmp_path: Path) -> None:

--- a/tests/config/test_config_package_api.py
+++ b/tests/config/test_config_package_api.py
@@ -66,8 +66,8 @@ def test_config_package_default_path_uses_runtime_config_root(
 
     config_file = config_pkg.resolve_default_path()
 
-    assert config_file == runtime_root / "lol-audio-unpack.ini"
-    assert config_file.parent == runtime_root
+    assert config_file == runtime_root / "config" / "lol-audio-unpack.ini"
+    assert config_file.parent == runtime_root / "config"
 
 
 def test_config_package_keeps_short_public_api() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,27 +10,6 @@ from lol_audio_unpack.utils.common import Singleton
 from lol_audio_unpack.utils.runtime_paths import detect_runtime_paths
 
 
-class FakeQSettings:
-    """测试环境使用的内存版 QSettings 替身。"""
-
-    class Format:
-        IniFormat = object()
-
-    class Scope:
-        UserScope = object()
-
-    _store: dict[str, object] = {}
-
-    def __init__(self, *args, **kwargs) -> None:
-        _ = args, kwargs
-
-    def value(self, key: str, default=None):
-        return self._store.get(key, default)
-
-    def setValue(self, key: str, value) -> None:
-        self._store[key] = value
-
-
 @pytest.fixture(autouse=True)
 def _reset_config_state(monkeypatch, tmp_path):
     # 避免测试受到本地环境变量污染
@@ -40,7 +19,6 @@ def _reset_config_state(monkeypatch, tmp_path):
 
     isolated_work_dir = tmp_path / "isolated_env"
     isolated_work_dir.mkdir(parents=True, exist_ok=True)
-    FakeQSettings._store = {}
 
     # 强制把默认配置目录切换到临时目录，避免读取真实配置文件
     monkeypatch.setattr(
@@ -70,7 +48,6 @@ def _reset_config_state(monkeypatch, tmp_path):
             executable=isolated_work_dir / "python.exe",
         ),
     )
-    monkeypatch.setattr(gui_config_module, "QSettings", FakeQSettings)
 
     Singleton._instances.pop(DataReader, None)
 

--- a/tests/gui/test_execution_page.py
+++ b/tests/gui/test_execution_page.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
+from lol_audio_unpack.gui.controllers.contracts import SharedDataLoadingState
 from lol_audio_unpack.gui.view.execution_page import ExecutionPage
 from lol_audio_unpack.gui.view.setting_page import SettingPage
 
@@ -139,6 +140,50 @@ def test_execution_page_primary_button_switches_to_cancel_when_task_running(qtbo
     execution_page._queue_task_draft()
 
     assert execution_page.create_task_btn.text() == "取消"
+
+
+def test_execution_page_blocks_task_creation_while_shared_data_is_busy(qtbot, monkeypatch) -> None:
+    """共享数据后台准备期间，执行中心不应创建任务。"""
+    _setting_page, execution_page = _build_linked_pages(qtbot)
+    started_tasks = []
+    monkeypatch.setattr("lol_audio_unpack.gui.view.execution_page.get_block_reason", lambda _cfg: None)
+    monkeypatch.setattr(
+        execution_page._queue_controller,
+        "start_task_worker",
+        started_tasks.append,
+    )
+
+    execution_page.set_shared_data_loading_state(
+        SharedDataLoadingState(message="正在刷新基础数据…", active=True)
+    )
+    execution_page._queue_task_draft()
+
+    assert execution_page.create_task_btn.text() == "准备数据中"
+    assert "正在刷新基础数据" in execution_page.create_task_btn.toolTip()
+    assert execution_page._queue_controller.draft_queue_size() == 0
+    assert started_tasks == []
+
+
+def test_execution_page_keeps_failure_as_block_reason_without_busy_lock(qtbot, monkeypatch) -> None:
+    """共享数据准备失败后应解除忙碌态，但继续给出明确阻止原因。"""
+    _setting_page, execution_page = _build_linked_pages(qtbot)
+    started_tasks = []
+    monkeypatch.setattr("lol_audio_unpack.gui.view.execution_page.get_block_reason", lambda _cfg: None)
+    monkeypatch.setattr(
+        execution_page._queue_controller,
+        "start_task_worker",
+        started_tasks.append,
+    )
+
+    execution_page.set_shared_data_loading_state(
+        SharedDataLoadingState(message="加载失败: 地图 banks 未生成", active=False)
+    )
+    execution_page._queue_task_draft()
+
+    assert execution_page.create_task_btn.text() == "创建任务"
+    assert "地图 banks 未生成" in execution_page.create_task_btn.toolTip()
+    assert execution_page._queue_controller.draft_queue_size() == 0
+    assert started_tasks == []
 
 
 def test_execution_page_absorbs_duplicate_create_calls_in_single_task_mode(qtbot, monkeypatch) -> None:

--- a/tests/gui/test_gui_config.py
+++ b/tests/gui/test_gui_config.py
@@ -1,18 +1,19 @@
-"""GUI 配置中的 WAV 默认值回归测试。"""
+"""GUI 配置持久化回归测试。"""
 
 from __future__ import annotations
 
+import configparser
 from pathlib import Path
 
-from PySide6.QtCore import QSettings
-
-from lol_audio_unpack.config import load_command_config
+from lol_audio_unpack.config import ConfigSection, load_command_config
 from lol_audio_unpack.gui.common.gui_config import GuiConfig
 from lol_audio_unpack.gui.theme.presets import get_accent_preset
 
 EXPECTED_WAV_WORKERS = 6
 EXPECTED_WAV_TIMEOUT = 9
 EXPECTED_WAV_RETRIES = 4
+DEFAULT_PREVIEW_VOLUME_PERCENT = 10
+EXPECTED_PREVIEW_VOLUME_PERCENT = 42
 
 
 def test_gui_config_load_reads_wav_command_defaults(tmp_path: Path) -> None:
@@ -86,61 +87,120 @@ def test_gui_config_save_updates_wav_group_enable_and_tuning(tmp_path: Path) -> 
     assert "wav = true" not in config_file.read_text(encoding="utf-8")
 
 
-def test_gui_config_load_migrates_legacy_theme_color_to_accent_preset(tmp_path: Path) -> None:
-    """旧主题色应迁移到固定 accent preset。"""
-    settings_file = tmp_path / "gui-settings.ini"
-    legacy_settings = QSettings(str(settings_file), QSettings.Format.IniFormat)
-    legacy_settings.setValue("theme_mode", "Dark")
-    legacy_settings.setValue("theme_color", get_accent_preset("purple").primary_hex)
-    legacy_settings.sync()
-
+def test_gui_config_uses_defaults_when_project_ini_is_missing() -> None:
+    """项目配置缺失时应使用 GUI 默认值。"""
     cfg = GuiConfig()
-    cfg._qs = QSettings(str(settings_file), QSettings.Format.IniFormat)
 
     cfg.load()
 
-    assert cfg.theme_mode == "Dark"
-    assert cfg.accent_preset_id == "purple"
-    assert cfg.theme_color.lower() == get_accent_preset("purple").primary_hex.lower()
+    assert cfg.preview_audio_volume_percent == DEFAULT_PREVIEW_VOLUME_PERCENT
 
 
-def test_gui_config_save_persists_theme_mode_and_accent_preset(tmp_path: Path) -> None:
-    """新主题配置应写回壳模式与 accent preset。"""
-    config_file = tmp_path / "lol-audio-unpack.ini"
-    settings_file = tmp_path / "gui-settings.ini"
+def test_gui_config_load_reads_gui_section_from_project_ini(tmp_path: Path) -> None:
+    """GUI 专有状态应从项目 INI 的 gui 分组读取。"""
+    config_file = tmp_path / "config" / "lol-audio-unpack.ini"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        (
+            "[gui]\n"
+            "vgmstream_path = tools/vgmstream/vgmstream-cli.exe\n"
+            "remote_snapshot_strategy = custom\n"
+            "remote_snapshot_version = 16.12\n"
+            "remote_snapshot_lcu_url = https://example.com/lcu.manifest\n"
+            "remote_snapshot_game_url = https://example.com/game.manifest\n"
+            "theme_mode = Dark\n"
+            "accent_preset_id = purple\n"
+            "page_smooth_scroll_enabled = true\n"
+            "widget_smooth_scroll_enabled = true\n"
+            "log_drawer_auto_collapse_enabled = false\n"
+            "console_log_level = warning\n"
+            "file_log_level = info\n"
+            f"preview_audio_volume_percent = {EXPECTED_PREVIEW_VOLUME_PERCENT}\n"
+            "preview_audio_output_device_key = device-a\n"
+        ),
+        encoding="utf-8",
+    )
 
     cfg = GuiConfig()
     cfg._config_file = config_file
-    cfg._qs = QSettings(str(settings_file), QSettings.Format.IniFormat)
+    cfg.load()
+
+    assert cfg.vgmstream_path == "tools/vgmstream/vgmstream-cli.exe"
+    assert cfg.remote_snapshot_strategy == "custom"
+    assert cfg.snapshot_version == "16.12"
+    assert cfg.snapshot_lcu_url == "https://example.com/lcu.manifest"
+    assert cfg.snapshot_game_url == "https://example.com/game.manifest"
+    assert cfg.theme_mode == "Dark"
+    assert cfg.accent_preset_id == "purple"
+    assert cfg.theme_color.lower() == get_accent_preset("purple").primary_hex.lower()
+    assert cfg.page_smooth_scroll_enabled is True
+    assert cfg.widget_smooth_scroll_enabled is True
+    assert cfg.log_drawer_auto_collapse_enabled is False
+    assert cfg.console_log_level == "WARNING"
+    assert cfg.file_log_level == "INFO"
+    assert cfg.preview_audio_volume_percent == EXPECTED_PREVIEW_VOLUME_PERCENT
+    assert cfg.preview_audio_output_device_key == "device-a"
+
+
+def test_gui_config_save_persists_gui_state_to_project_ini(tmp_path: Path) -> None:
+    """保存 GUI 配置时应把 GUI 状态统一写入项目 INI。"""
+    config_file = tmp_path / "config" / "lol-audio-unpack.ini"
+    cfg = GuiConfig()
+    cfg._config_file = config_file
+    cfg.vgmstream_path = "tools/vgmstream/vgmstream-cli.exe"
+    cfg.remote_snapshot_strategy = "custom"
+    cfg.snapshot_version = "16.12"
+    cfg.snapshot_lcu_url = "https://example.com/lcu.manifest"
+    cfg.snapshot_game_url = "https://example.com/game.manifest"
     cfg.theme_mode = "Dark"
     cfg.accent_preset_id = "orange"
+    cfg.page_smooth_scroll_enabled = True
+    cfg.widget_smooth_scroll_enabled = True
+    cfg.log_drawer_auto_collapse_enabled = False
+    cfg.console_log_level = "WARNING"
+    cfg.file_log_level = "INFO"
+    cfg.preview_audio_volume_percent = EXPECTED_PREVIEW_VOLUME_PERCENT
+    cfg.preview_audio_output_device_key = "device-a"
 
-    cfg.save_theme_preferences()
-    cfg._qs.sync()
+    cfg.save()
 
     reloaded = GuiConfig()
     reloaded._config_file = config_file
-    reloaded._qs = QSettings(str(settings_file), QSettings.Format.IniFormat)
     reloaded.load()
 
+    assert reloaded.vgmstream_path == "tools/vgmstream/vgmstream-cli.exe"
+    assert reloaded.remote_snapshot_strategy == "custom"
+    assert reloaded.snapshot_version == "16.12"
+    assert reloaded.snapshot_lcu_url == "https://example.com/lcu.manifest"
+    assert reloaded.snapshot_game_url == "https://example.com/game.manifest"
     assert reloaded.theme_mode == "Dark"
     assert reloaded.accent_preset_id == "orange"
     assert reloaded.theme_color.lower() == get_accent_preset("orange").primary_hex.lower()
+    assert reloaded.page_smooth_scroll_enabled is True
+    assert reloaded.widget_smooth_scroll_enabled is True
+    assert reloaded.log_drawer_auto_collapse_enabled is False
+    assert reloaded.console_log_level == "WARNING"
+    assert reloaded.file_log_level == "INFO"
+    assert reloaded.preview_audio_volume_percent == EXPECTED_PREVIEW_VOLUME_PERCENT
+    assert reloaded.preview_audio_output_device_key == "device-a"
 
 
-def test_gui_config_save_theme_preferences_stops_writing_legacy_theme_color(tmp_path: Path) -> None:
-    """新主题配置不应继续把 legacy theme_color 作为主写回字段。"""
-    settings_file = tmp_path / "gui-settings.ini"
-
+def test_gui_config_save_theme_preferences_updates_project_ini_only(tmp_path: Path) -> None:
+    """主题快速保存只应更新项目 INI 的主题字段并保留其他 GUI 字段。"""
+    config_file = tmp_path / "config" / "lol-audio-unpack.ini"
     cfg = GuiConfig()
-    cfg._qs = QSettings(str(settings_file), QSettings.Format.IniFormat)
+    cfg._config_file = config_file
+    cfg.preview_audio_volume_percent = EXPECTED_PREVIEW_VOLUME_PERCENT
+    cfg.save()
     cfg.theme_mode = "Light"
     cfg.accent_preset_id = "blue"
 
     cfg.save_theme_preferences()
-    cfg._qs.sync()
 
-    stored = QSettings(str(settings_file), QSettings.Format.IniFormat)
-    assert stored.value("theme_mode") == "Light"
-    assert stored.value("accent_preset_id") == "blue"
-    assert stored.value("theme_color") is None
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str
+    parser.read(config_file, encoding="utf-8")
+    assert parser[ConfigSection.GUI]["theme_mode"] == "Light"
+    assert parser[ConfigSection.GUI]["accent_preset_id"] == "blue"
+    assert parser[ConfigSection.GUI]["preview_audio_volume_percent"] == str(EXPECTED_PREVIEW_VOLUME_PERCENT)
+    assert "theme_color" not in parser[ConfigSection.GUI]

--- a/tests/gui/test_gui_config_onboarding.py
+++ b/tests/gui/test_gui_config_onboarding.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from lol_audio_unpack.gui.common.gui_config import GuiConfig
 from lol_audio_unpack.gui.controllers.onboarding_state import GUIDE_VERSION
 
@@ -66,3 +68,29 @@ def test_new_onboarding_version_ignores_old_completion() -> None:
     cfg.mark_onboarding_completed(OLD_GUIDE_VERSION)
 
     assert cfg.should_show_onboarding(GUIDE_VERSION) is True
+
+
+def test_completed_onboarding_persists_to_project_ini(tmp_path: Path) -> None:
+    """完成状态应写入项目 INI 并能跨实例读取。"""
+    config_file = tmp_path / "config" / "lol-audio-unpack.ini"
+    cfg = GuiConfig()
+    cfg._config_file = config_file
+
+    cfg.mark_onboarding_completed(GUIDE_VERSION)
+
+    reloaded = GuiConfig()
+    reloaded._config_file = config_file
+    assert reloaded.should_show_onboarding(GUIDE_VERSION) is False
+
+
+def test_skipped_onboarding_persists_to_project_ini(tmp_path: Path) -> None:
+    """跳过状态应写入项目 INI 并能跨实例读取。"""
+    config_file = tmp_path / "config" / "lol-audio-unpack.ini"
+    cfg = GuiConfig()
+    cfg._config_file = config_file
+
+    cfg.mark_onboarding_skipped(GUIDE_VERSION)
+
+    reloaded = GuiConfig()
+    reloaded._config_file = config_file
+    assert reloaded.should_show_onboarding(GUIDE_VERSION) is False

--- a/tests/gui/test_item_lookup_page.py
+++ b/tests/gui/test_item_lookup_page.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from PySide6.QtWidgets import QApplication
 
+import lol_audio_unpack.gui.view.item_lookup_page as item_lookup_page_module
 from lol_audio_unpack.gui.components.item_lookup_grid import ITEM_MODE_ARENA
 from lol_audio_unpack.gui.service.item_catalog import ItemCatalogPayload, ItemRecord
 from lol_audio_unpack.gui.view.item_lookup_page import ItemLookupPage
@@ -85,3 +88,20 @@ def test_item_lookup_page_shows_failure_state_without_hiding_refresh(qtbot) -> N
     assert page.refresh_button.isEnabled() is True
     assert "装备数据加载失败" in page.status_label.text()
     assert "offline" in page.status_label.toolTip()
+
+
+def test_item_lookup_page_logs_load_failure(qtbot, monkeypatch) -> None:
+    """装备数据加载失败时应写入日志，便于定位网络或数据格式问题。"""
+    errors: list[str] = []
+    monkeypatch.setattr(
+        item_lookup_page_module,
+        "logger",
+        SimpleNamespace(error=errors.append),
+    )
+
+    page = ItemLookupPage(fetch_items_fn=lambda: (_ for _ in ()).throw(RuntimeError("offline")), start_worker_fn=_run_worker_sync)
+    qtbot.addWidget(page)
+
+    page.load_items()
+
+    assert errors == ["装备数据加载失败: offline"]

--- a/tests/gui/test_setting_page_theme_preset.py
+++ b/tests/gui/test_setting_page_theme_preset.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import configparser
 from pathlib import Path
 
-from PySide6.QtCore import QSettings
 from qfluentwidgets import Theme, isDarkTheme, qconfig
 from qfluentwidgets.common.icon import writeSvg
 
@@ -16,11 +16,8 @@ EXPECTED_ICON_CHANNEL_TOLERANCE = 8
 
 
 def _use_temp_settings(page: SettingPage, tmp_path: Path) -> None:
-    """把页面配置切到临时 QSettings 文件。"""
-    settings_file = tmp_path / "gui-settings.ini"
-    page.config._qs = QSettings(str(settings_file), QSettings.Format.IniFormat)
-    page.config._qs.clear()
-    page.config._qs.sync()
+    """把页面配置切到临时项目 INI 文件。"""
+    page.config._config_file = tmp_path / "config" / "lol-audio-unpack.ini"
 
 
 def test_setting_page_applies_saved_accent_preset_to_selector(qtbot, tmp_path: Path) -> None:
@@ -48,7 +45,10 @@ def test_setting_page_persists_selected_accent_preset(qtbot, tmp_path: Path) -> 
     qtbot.wait(0)
 
     assert page.config.accent_preset_id == "green"
-    assert page.config._qs.value("accent_preset_id") == "green"
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str
+    parser.read(page.config._config_file, encoding="utf-8")
+    assert parser["gui"]["accent_preset_id"] == "green"
     assert qconfig.themeColor.value.name().lower() == get_accent_preset("green").resolve_primary_hex(dark=isDarkTheme()).lower()
 
 

--- a/tests/gui/test_single_instance.py
+++ b/tests/gui/test_single_instance.py
@@ -1,0 +1,171 @@
+"""GUI 单实例守卫测试。"""
+
+from __future__ import annotations
+
+from lol_audio_unpack.gui.single_instance import (
+    ACTIVATE_MESSAGE,
+    acquire_or_activate,
+    activate_window,
+)
+
+
+class _FakeSignal:
+    """记录信号连接。"""
+
+    def __init__(self) -> None:
+        self.slots = []
+
+    def connect(self, slot) -> None:
+        """记录一个槽函数。"""
+        self.slots.append(slot)
+
+
+class _FakeServer:
+    """模拟 ``QLocalServer`` 的 listen/remove 行为。"""
+
+    listen_results: list[bool] = []
+    instances: list[_FakeServer] = []
+    removed_names: list[str] = []
+
+    def __init__(self, parent=None) -> None:
+        self.parent = parent
+        self.newConnection = _FakeSignal()
+        self.listened_names: list[str] = []
+        _FakeServer.instances.append(self)
+
+    def listen(self, name: str) -> bool:
+        """按预设结果返回监听状态。"""
+        self.listened_names.append(name)
+        return _FakeServer.listen_results.pop(0)
+
+    @classmethod
+    def removeServer(cls, name: str) -> None:  # noqa: N802
+        """记录清理僵尸本地服务名。"""
+        cls.removed_names.append(name)
+
+
+class _ConnectedSocket:
+    """模拟可连接到已有实例的 ``QLocalSocket``。"""
+
+    written_payloads: list[bytes] = []
+
+    def __init__(self) -> None:
+        self.server_name = ""
+
+    def connectToServer(self, name: str) -> None:  # noqa: N802
+        """记录连接目标。"""
+        self.server_name = name
+
+    def waitForConnected(self, _timeout_ms: int) -> bool:  # noqa: N802
+        """模拟连接成功。"""
+        return True
+
+    def write(self, payload: bytes) -> int:
+        """记录激活消息。"""
+        self.written_payloads.append(payload)
+        return len(payload)
+
+    def flush(self) -> bool:
+        """模拟 flush 成功。"""
+        return True
+
+    def waitForBytesWritten(self, _timeout_ms: int) -> bool:  # noqa: N802
+        """模拟写入成功。"""
+        return True
+
+    def disconnectFromServer(self) -> None:  # noqa: N802
+        """模拟主动断开。"""
+        return None
+
+
+class _DisconnectedSocket(_ConnectedSocket):
+    """模拟无法连接到已有实例的 ``QLocalSocket``。"""
+
+    def waitForConnected(self, _timeout_ms: int) -> bool:  # noqa: N802
+        """模拟连接失败。"""
+        return False
+
+
+class _FakeWindow:
+    """模拟可被激活的窗口。"""
+
+    def __init__(self, *, visible: bool, minimized: bool) -> None:
+        self._visible = visible
+        self._minimized = minimized
+        self.calls: list[str] = []
+
+    def isVisible(self) -> bool:  # noqa: N802
+        """返回窗口可见状态。"""
+        return self._visible
+
+    def isMinimized(self) -> bool:  # noqa: N802
+        """返回窗口最小化状态。"""
+        return self._minimized
+
+    def show(self) -> None:
+        """记录普通显示调用。"""
+        self.calls.append("show")
+
+    def showNormal(self) -> None:  # noqa: N802
+        """记录从最小化恢复调用。"""
+        self.calls.append("showNormal")
+
+    def raise_(self) -> None:
+        """记录置顶调用。"""
+        self.calls.append("raise_")
+
+    def activateWindow(self) -> None:  # noqa: N802
+        """记录激活调用。"""
+        self.calls.append("activateWindow")
+
+
+def _reset_fakes() -> None:
+    """清理所有 fake 的共享记录。"""
+    _FakeServer.listen_results = []
+    _FakeServer.instances = []
+    _FakeServer.removed_names = []
+    _ConnectedSocket.written_payloads = []
+
+
+def test_acquire_or_activate_requests_existing_instance() -> None:
+    """已有本地服务时，新进程应发激活消息并退出。"""
+    _reset_fakes()
+    _FakeServer.listen_results = [False]
+
+    guard = acquire_or_activate(
+        key="test-instance",
+        server_cls=_FakeServer,
+        socket_cls=_ConnectedSocket,
+        timeout_ms=1,
+    )
+
+    assert guard is None
+    assert _ConnectedSocket.written_payloads == [ACTIVATE_MESSAGE]
+    assert _FakeServer.removed_names == []
+
+
+def test_acquire_or_activate_removes_stale_server_name() -> None:
+    """连接不到已有实例时，应清理僵尸服务名并重新监听。"""
+    _reset_fakes()
+    _FakeServer.listen_results = [False, True]
+
+    guard = acquire_or_activate(
+        key="stale-instance",
+        server_cls=_FakeServer,
+        socket_cls=_DisconnectedSocket,
+        timeout_ms=1,
+    )
+
+    assert guard is not None
+    assert _FakeServer.removed_names == ["stale-instance"]
+    assert _ConnectedSocket.written_payloads == []
+    assert _FakeServer.instances[-1].newConnection.slots
+
+
+def test_activate_window_restores_minimized_window() -> None:
+    """收到激活请求时，最小化窗口应先恢复再置前。"""
+    window = _FakeWindow(visible=True, minimized=True)
+
+    activate_window(window)
+
+    assert window.calls == ["showNormal", "raise_", "activateWindow"]

--- a/tests/gui/test_task_runner.py
+++ b/tests/gui/test_task_runner.py
@@ -50,6 +50,19 @@ def _build_task(
     )
 
 
+class _ReadyMapBanksReader:
+    """提供已就绪地图 banks 的轻量测试读取器。"""
+
+    def __init__(self, *, ctx) -> None:
+        self.ctx = ctx
+
+    def get_maps(self) -> list[dict]:
+        return [{"id": 11}]
+
+    def get_map_banks(self, _map_id: int) -> dict:
+        return {"banks": {"VO": [["map.wpk"]]}}
+
+
 def test_build_runtime_settings_forces_local_path_when_packaged(monkeypatch) -> None:
     monkeypatch.setattr(
         task_runner,
@@ -233,6 +246,7 @@ def test_run_execution_task_runs_wav_stage_between_extract_and_mapping(monkeypat
         ),
     )
     monkeypatch.setattr(task_runner, "create_app_context", lambda *, settings: runtime_context)
+    monkeypatch.setattr(task_runner, "DataReader", _ReadyMapBanksReader)
 
     class FakeApp:
         def __init__(self, app_context) -> None:
@@ -316,3 +330,54 @@ def test_run_execution_task_allows_wav_stage_without_extract(monkeypatch, tmp_pa
 
     assert events == ["wav"]
     assert result.completed_steps == ("音频转码",)
+
+
+def test_run_execution_task_rejects_missing_map_banks_before_runtime_steps(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """地图 banks 尚未生成时，GUI 任务不应静默跳过地图输出。"""
+    task = _build_task(source_mode="local_path", run_mapping=False)
+    runtime_context = SimpleNamespace(
+        paths=SimpleNamespace(
+            manifest_path=tmp_path / "manifest",
+            audio_path=tmp_path / "audios",
+            wav_path=tmp_path / "wavs",
+            report_path=tmp_path / "reports",
+        ),
+        runtime_cache={},
+        config=SimpleNamespace(dev_mode=False),
+    )
+    data_dir = runtime_context.paths.manifest_path / "16.5"
+    data_dir.mkdir(parents=True)
+    (data_dir / "data.msgpack").write_bytes(b"placeholder")
+
+    class FakeReader:
+        version = "16.5"
+
+        def __init__(self, *, ctx) -> None:
+            pass
+
+        def get_champions(self) -> list[dict]:
+            return [{"id": 1}]
+
+        def get_maps(self) -> list[dict]:
+            return [{"id": 11}]
+
+        def get_map_banks(self, _map_id: int):
+            return None
+
+    class FakeApp:
+        def __init__(self, app_context) -> None:
+            self.ctx = app_context
+
+        def extract(self, _options, **_kwargs) -> None:
+            pytest.fail("地图 banks 缺失时不应进入 extract")
+
+    monkeypatch.setattr(task_runner, "create_app_context", lambda *, settings: runtime_context)
+    monkeypatch.setattr(task_runner, "DataReader", FakeReader)
+    monkeypatch.setattr(task_runner, "LolAudioUnpackApp", FakeApp)
+    signals = SimpleNamespace(progress=SimpleNamespace(emit=lambda _payload: None))
+
+    with pytest.raises(RuntimeError, match="地图基础数据仍未准备完成"):
+        task_runner.run_execution_task(task, signals)

--- a/tests/gui/test_window_shell_controller.py
+++ b/tests/gui/test_window_shell_controller.py
@@ -162,6 +162,9 @@ def test_bind_shared_data_controller_signals_wires_payload_consumers() -> None:
             events.append(("loading", (message, active)))
 
     class _FakeExecution:
+        def set_shared_data_loading_state(self, state) -> None:
+            events.append(("exec_loading", (state.message, state.active)))
+
         def clear_entity_data(self) -> None:
             events.append(("exec_clear", None))
 
@@ -200,6 +203,7 @@ def test_bind_shared_data_controller_signals_wires_payload_consumers() -> None:
     controller.notice_requested.emit(type("Notice", (), {"title": "ok", "content": "done", "level": "success"})())
 
     assert ("loading", ("loading", True)) in events
+    assert ("exec_loading", ("loading", True)) in events
     assert ("exec_replace", ("champions", ({"id": 1},))) in events
     assert ("overview_replace", ("champions", ({"id": 1},))) in events
     assert ("notice", ("ok", "done", "success")) in events

--- a/tests/manager/test_manager_utils.py
+++ b/tests/manager/test_manager_utils.py
@@ -116,6 +116,30 @@ def test_build_metadata_payload():
     assert "createdAt" in metadata
 
 
+def test_build_metadata_payload_prefers_injected_build_version(monkeypatch):
+    monkeypatch.setenv("LOL_AUDIO_UNPACK_BUILD_VERSION", "3.7.1.dev14+gabc123")
+
+    result = mutils.build_metadata_payload("16.12", ["zh_CN"])
+
+    assert result["metadata"]["scriptVersion"] == "3.7.1.dev14+gabc123"
+
+
+def test_build_metadata_payload_does_not_warn_when_injected_version_exists(monkeypatch):
+    warnings: list[str] = []
+    monkeypatch.setenv("LOL_AUDIO_UNPACK_BUILD_VERSION", "3.7.1")
+    monkeypatch.setattr(
+        mutils,
+        "get_package_version",
+        lambda _name: (_ for _ in ()).throw(mutils.PackageNotFoundError()),
+    )
+    monkeypatch.setattr(mutils.logger, "warning", warnings.append)
+
+    result = mutils.build_metadata_payload("16.12", ["zh_CN"])
+
+    assert result["metadata"]["scriptVersion"] == "3.7.1"
+    assert warnings == []
+
+
 def test_needs_update_behavior(tmp_path):
     base = tmp_path / "manifest" / "data"
     base.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/runtime/test_runtime_paths.py
+++ b/tests/runtime/test_runtime_paths.py
@@ -25,7 +25,7 @@ def test_detect_runtime_paths_uses_cwd_for_source_runs(tmp_path: Path) -> None:
 
     assert runtime_paths.is_frozen is False
     assert runtime_paths.launch_root == source_cwd.resolve()
-    assert runtime_paths.config_root == source_cwd.resolve()
+    assert runtime_paths.config_root == source_cwd.resolve() / "config"
     assert runtime_paths.bundle_root == source_cwd.resolve()
     assert runtime_paths.executable_path == executable.resolve(strict=False)
 
@@ -46,7 +46,7 @@ def test_detect_runtime_paths_uses_executable_dir_for_frozen_runs(tmp_path: Path
 
     assert runtime_paths.is_frozen is True
     assert runtime_paths.launch_root == expected_root
-    assert runtime_paths.config_root == expected_root
+    assert runtime_paths.config_root == expected_root / "config"
     assert runtime_paths.bundle_root == expected_root
     assert runtime_paths.executable_path == executable.resolve(strict=False)
 

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -27,6 +27,14 @@ def test_pyinstaller_entry_files_exist() -> None:
     assert (PYINSTALLER_DIR / "runtime_hook_chdir.py").is_file()
 
 
+def test_gui_entry_calls_freeze_support_before_qt_imports() -> None:
+    """GUI 入口必须先处理 PyInstaller multiprocessing 子进程参数。"""
+    entry_text = (PROJECT_ROOT / "src" / "lol_audio_unpack" / "gui" / "__main__.py").read_text(encoding="utf-8")
+
+    assert "multiprocessing.freeze_support()" in entry_text
+    assert entry_text.index("multiprocessing.freeze_support()") < entry_text.index("from PySide6")
+
+
 def test_pyinstaller_spec_supports_default_onefile_and_optional_onedir() -> None:
     """spec 文件应默认 onefile，并允许切换到 onedir。"""
     spec_text = (PYINSTALLER_DIR / "gui.spec").read_text(encoding="utf-8")

--- a/tests/test_test_runtime_policy.py
+++ b/tests/test_test_runtime_policy.py
@@ -53,10 +53,11 @@ def test_gui_config_default_env_file_stays_inside_repo_temp() -> None:
     assert cfg._config_file.resolve().is_relative_to(PYTEST_TEMP_ROOT)
 
 
-def test_gui_config_uses_fake_qsettings_backend_in_tests() -> None:
-    """测试环境中的 GuiConfig 不应直接使用系统真实 QSettings。"""
+def test_gui_config_project_ini_lives_under_config_dir() -> None:
+    """测试环境中的 GuiConfig 项目 INI 应落在隔离 config 目录。"""
     cfg = GuiConfig()
-    assert type(cfg._qs).__name__ == "FakeQSettings"
+    assert cfg._config_file.name == "lol-audio-unpack.ini"
+    assert cfg._config_file.parent.name == "config"
 
 
 def test_tests_do_not_embed_nonportable_absolute_path_literals() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "lol-audio-unpack"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "league-tools" },


### PR DESCRIPTION
## Why

本次发布把打包版 GUI 的关键稳定性修复合入 `main`，目标是解决：

- 打包后点击“创建任务”可能重新打开一个程序窗口，导致任务队列表面启动但没有输出。
- 后台共享数据还没准备好时仍可创建地图任务，缺少 map banks 时容易静默失败。
- 打包版 metadata 无法获取包版本，生成数据时可能回退并提示安装问题。
- GUI 项目配置分散在用户全局 QSettings、程序根目录 INI 和 qconfig，打包测试时难以确认真实状态。
- 装备查询加载失败没有错误日志，不利于定位网络、代理、TLS、超时或官网数据变化。

## What

- 在 GUI 入口加入 `multiprocessing.freeze_support()`，并新增 Qt 本地单例守护，二次启动会激活已有窗口。
- 执行页接入共享数据加载状态，后台数据准备中禁用或拦截创建任务，并在任务执行前校验地图 banks。
- 项目自有 GUI 配置统一到 `config/lol-audio-unpack.ini`，GUI 偏好写入 `[gui]`，新手引导状态写入 `[onboarding]`。
- metadata `scriptVersion` 优先使用 PyInstaller 注入的 `LOL_AUDIO_UNPACK_BUILD_VERSION`，再回退运行时版本和包 metadata。
- 装备查询加载失败时写入错误日志。
- 将正式版本同步到 `3.7.2`，并新增 `.github/release-notes/v3.7.2.md`。

## Compatibility / Risk

- 旧 QSettings 和旧程序根目录 INI 不迁移；这是有意行为，因为此前打包版存在阻断正常解包的问题，本版本按新的 `config/` 目录规则重新开始。
- 默认输出目录仍是运行目录下的 `output/`，CLI 参数、WEM 输出结构和事件映射输出格式不变。
- GUI 单例依赖 Qt local server；异常时会回退为继续启动窗口，不阻断启动。

## Test

- `uv lock --locked` -> passed
- `uv run pytest tests/gui/test_execution_page.py tests/gui/test_window_shell_controller.py tests/gui/test_task_runner.py tests/gui/test_execution_queue_controller.py tests/gui/test_execution_process_worker.py tests/test_pyinstaller_packaging.py tests/gui/test_single_instance.py tests/runtime/test_runtime_paths.py tests/config/test_config_package_api.py tests/app/test_app_context.py tests/gui/test_gui_config.py tests/gui/test_gui_config_onboarding.py tests/gui/test_setting_page_theme_preset.py tests/manager/test_manager_utils.py tests/test_test_runtime_policy.py tests/gui/test_item_catalog.py tests/gui/test_item_lookup_grid.py tests/gui/test_item_lookup_page.py -q` -> `148 passed`
- `uv run ruff check <changed gui/config/runtime/version/tests scope>` -> passed
- `uv run --no-sync python scripts/pyinstaller/build_gui.py --skip-sync --clean` -> passed, generated `.temp/pyinstaller/dist/LolAudioUnpack.exe`
