### PR TITLE
refactor: 拆分远端工作流与 BinUpdater 编排

### DIFF
--- a/src/lol_audio_unpack/app/facade.py
+++ b/src/lol_audio_unpack/app/facade.py
@@ -7,11 +7,9 @@ Manager 与流程函数。
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import replace
 from pathlib import Path
 
 from loguru import logger
-from riotmanifest import DecompressError, DownloadBatchError, DownloadError
 
 from lol_audio_unpack.manager import BinUpdater, DataReader, DataUpdater
 from lol_audio_unpack.mapping import (
@@ -28,11 +26,9 @@ from lol_audio_unpack.unpack import unpack_all, unpack_champions, unpack_maps
 from .artifacts import resolve_audio_paths, resolve_mapping_path
 from .path_layout import get_output_dir_name
 from .remote import RemoteEntityCallbackPayload, RemoteEntityWorkItem
-from .targets import iter_entity_refs
+from .remote_workflow import RemoteWorkflowOrchestrator
 from .types import AppContext, OperationOptions, SourceMode
 
-DEFAULT_DOWNLOAD_RETRIES = 3
-DEFAULT_ENTITY_RETRIES = 3
 UPDATE_PREPARED_KEY = "update_data_prepared_force"
 
 
@@ -163,79 +159,6 @@ class LolAudioUnpackApp:
             return None
         return RemotePreparer(ctx=self.ctx)
 
-    @staticmethod
-    def _merge_remote_work_item(
-        work_items: dict[tuple[str, int], RemoteEntityWorkItem],
-        *,
-        entity_type: str,
-        entity_id: int,
-        need_extract: bool,
-        need_mapping: bool,
-    ) -> None:
-        """注册或合并远端实体工作项。"""
-        key = (entity_type, entity_id)
-        existing = work_items.get(key)
-        if existing is None:
-            work_items[key] = RemoteEntityWorkItem(
-                entity_type=entity_type,
-                entity_id=entity_id,
-                need_extract=need_extract,
-                need_mapping=need_mapping,
-            )
-            return
-
-        work_items[key] = RemoteEntityWorkItem(
-            entity_type=entity_type,
-            entity_id=entity_id,
-            need_extract=existing.need_extract or need_extract,
-            need_mapping=existing.need_mapping or need_mapping,
-        )
-
-    def _register_remote_work_items(  # noqa: PLR0913
-        self,
-        work_items: dict[tuple[str, int], RemoteEntityWorkItem],
-        *,
-        reader: DataReader,
-        opts: OperationOptions | None,
-        need_extract: bool,
-        need_mapping: bool,
-        include_champions: bool,
-        include_maps: bool,
-    ) -> None:
-        """根据操作范围生成远端实体工作项。"""
-        if opts is None:
-            return
-
-        for entity_type, entity_id in iter_entity_refs(
-            reader,
-            champion_ids=opts.champion_ids,
-            map_ids=opts.map_ids,
-            include_champions=include_champions,
-            include_maps=include_maps,
-        ):
-            self._merge_remote_work_item(
-                work_items,
-                entity_type=entity_type,
-                entity_id=entity_id,
-                need_extract=need_extract,
-                need_mapping=need_mapping,
-            )
-
-    @staticmethod
-    def _build_entity_options(
-        opts: OperationOptions,
-        *,
-        entity_type: str,
-        entity_id: int,
-    ) -> OperationOptions:
-        """将批量操作选项收窄为单实体选项。"""
-        is_champion = entity_type == "champion"
-        return replace(
-            opts,
-            champion_ids=(entity_id,) if is_champion else None,
-            map_ids=(entity_id,) if not is_champion else None,
-        )
-
     def _build_entity_data(
         self,
         reader: DataReader,
@@ -274,70 +197,6 @@ class LolAudioUnpackApp:
             return f"{entity_data.entity_name}·{entity_data.entity_title}"
         return entity_data.entity_name
 
-    @staticmethod
-    def _is_retryable_download_error(exc: BaseException) -> bool:
-        """判断是否属于可重试的远端下载错误。"""
-        return isinstance(exc, (DownloadError, DecompressError, DownloadBatchError))
-
-    def _prepare_entity_wads(  # noqa: PLR0913
-        self,
-        remote_preparer: RemotePreparer,
-        *,
-        reader: DataReader,
-        champion_ids: tuple[int, ...] | None,
-        map_ids: tuple[int, ...] | None,
-        include_champions: bool,
-        include_maps: bool,
-        need_extract: bool,
-        need_mapping: bool,
-        download_retry_attempts: int,
-        work_item: RemoteEntityWorkItem,
-        entity_attempt: int,
-        entity_retry_attempts: int,
-    ) -> None:
-        """按下载错误重试准备单实体所需 WAD。"""
-        for download_attempt in range(1, download_retry_attempts + 1):
-            try:
-                remote_preparer.prepare_entity_wads(
-                    reader=reader,
-                    champion_ids=champion_ids,
-                    map_ids=map_ids,
-                    include_champions=include_champions,
-                    include_maps=include_maps,
-                    need_extract=need_extract,
-                    need_mapping=need_mapping,
-                )
-                return
-            except Exception as exc:
-                if not self._is_retryable_download_error(exc):
-                    raise
-                if download_attempt >= download_retry_attempts:
-                    raise
-                logger.warning(
-                    "remote 实体 {} {} 下载 WAD 失败，准备重试 {}/{}（实体重试 {}/{}）：{}",
-                    work_item.entity_type,
-                    work_item.entity_id,
-                    download_attempt + 1,
-                    download_retry_attempts,
-                    entity_attempt,
-                    entity_retry_attempts,
-                    exc,
-                )
-
-    def _raise_entity_failure(
-        self,
-        *,
-        work_item: RemoteEntityWorkItem,
-        entity_retry_attempts: int,
-        exc: Exception,
-    ) -> None:
-        """在实体重试耗尽后抛出带上下文的错误。"""
-        raise RuntimeError(
-            "remote 实体执行失败且已超过重试阈值："
-            f"{work_item.entity_type} {work_item.entity_id} 已尝试 {entity_retry_attempts} 次；"
-            "当前解包脚本可能无法正常解包，可能是网络持续异常、二进制文件版本更新或上游资源结构变化导致。"
-        ) from exc
-
     def cleanup_remote_artifacts(self) -> None:
         """在 remote 模式下按配置清理已登记的远端产物。"""
         if self.ctx.config.source_mode is not SourceMode.REMOTE_SNAPSHOT:
@@ -353,232 +212,28 @@ class LolAudioUnpackApp:
         if cleanup_result:
             logger.info(f"远端准备产物清理完成: {cleanup_result}")
 
-    def build_work_items(  # noqa: PLR0913
-        self,
-        *,
-        extract_options: OperationOptions | None = None,
-        mapping_options: OperationOptions | None = None,
-        extract_include_champions: bool = True,
-        extract_include_maps: bool = True,
-        mapping_include_champions: bool = True,
-        mapping_include_maps: bool = True,
-    ) -> list[RemoteEntityWorkItem]:
-        """构建 remote 模式下的实体工作项队列。
-
-        Args:
-            extract_options: extract 阶段的操作选项；为 ``None`` 表示不执行 extract。
-            mapping_options: mapping 阶段的操作选项；为 ``None`` 表示不执行 mapping。
-            extract_include_champions: extract 阶段是否包含英雄。
-            extract_include_maps: extract 阶段是否包含地图。
-            mapping_include_champions: mapping 阶段是否包含英雄。
-            mapping_include_maps: mapping 阶段是否包含地图。
-
-        Returns:
-            已按实体类型与 ID 排序的工作项列表。
-
-        Raises:
-            ValueError: 当前不是 ``remote_snapshot`` 模式。
-        """
-        if self.ctx.config.source_mode is not SourceMode.REMOTE_SNAPSHOT:
-            raise ValueError("仅 remote_snapshot 模式支持按实体拆批执行。")
-
-        reader = self._create_reader()
-        work_items: dict[tuple[str, int], RemoteEntityWorkItem] = {}
-        self._register_remote_work_items(
-            work_items,
-            reader=reader,
-            opts=extract_options,
-            need_extract=True,
-            need_mapping=False,
-            include_champions=extract_include_champions,
-            include_maps=extract_include_maps,
-        )
-        self._register_remote_work_items(
-            work_items,
-            reader=reader,
-            opts=mapping_options,
-            need_extract=False,
-            need_mapping=True,
-            include_champions=mapping_include_champions,
-            include_maps=mapping_include_maps,
-        )
-        return sorted(
-            work_items.values(),
-            key=lambda item: (item.entity_type != "champion", item.entity_id),
+    def _remote_orchestrator(self) -> RemoteWorkflowOrchestrator:
+        """构造远端工作流编排器，注入标准操作与实体解析回调。"""
+        return RemoteWorkflowOrchestrator(
+            self.ctx,
+            update_fn=self.update,
+            extract_fn=self.extract,
+            mapping_fn=self.mapping,
+            cleanup_fn=self.cleanup_remote_artifacts,
+            build_entity_data_fn=self._build_entity_data,
+            resolve_audio_paths_fn=self._resolve_audio_paths,
+            resolve_mapping_path_fn=self._resolve_mapping_path,
+            create_reader_fn=self._create_reader,
+            remote_preparer_factory=lambda: RemotePreparer(ctx=self.ctx),
         )
 
-    def run_workflow(  # noqa: PLR0913
-        self,
-        *,
-        update_options: OperationOptions | None = None,
-        update_target: str = "all",
-        extract_options: OperationOptions | None = None,
-        mapping_options: OperationOptions | None = None,
-        extract_include_champions: bool = True,
-        extract_include_maps: bool = True,
-        mapping_include_champions: bool = True,
-        mapping_include_maps: bool = True,
-        on_entity_complete: Callable[[RemoteEntityCallbackPayload], None] | None = None,
-        progress_callback: Callable[[int, int, str], None] | None = None,
-        download_retry_attempts: int = DEFAULT_DOWNLOAD_RETRIES,
-        entity_retry_attempts: int = DEFAULT_ENTITY_RETRIES,
-    ) -> None:
-        """按实体拆批执行 remote 流程，并在每轮后清理远端产物。
+    def build_work_items(self, **kwargs) -> list[RemoteEntityWorkItem]:
+        """构建 remote 模式下的实体工作项队列（委托 RemoteWorkflowOrchestrator）。"""
+        return self._remote_orchestrator().build_work_items(**kwargs)
 
-        Args:
-            update_options: 可选的 update 选项；提供时会先执行一次全局 update。
-            update_target: update 阶段目标，语义与 ``update(..., target=...)`` 相同。
-            extract_options: extract 阶段的操作选项；为 ``None`` 表示跳过。
-            mapping_options: mapping 阶段的操作选项；为 ``None`` 表示跳过。
-            extract_include_champions: extract 阶段是否包含英雄。
-            extract_include_maps: extract 阶段是否包含地图。
-            mapping_include_champions: mapping 阶段是否包含英雄。
-            mapping_include_maps: mapping 阶段是否包含地图。
-            on_entity_complete: 当前实体执行完成后的可选回调。
-            progress_callback: 每个实体处理结束后的可选进度回调。
-            download_retry_attempts: 单次实体尝试内，WAD 下载类错误的最大重试次数。
-            entity_retry_attempts: 单实体完整流程失败时的最大重试次数。
-
-        Raises:
-            ValueError: 当前不是 ``remote_snapshot`` 模式。
-        """
-        if self.ctx.config.source_mode is not SourceMode.REMOTE_SNAPSHOT:
-            raise ValueError("仅 remote_snapshot 模式支持按实体拆批执行。")
-        if download_retry_attempts < 1:
-            raise ValueError("download_retry_attempts 必须大于等于 1。")
-        if entity_retry_attempts < 1:
-            raise ValueError("entity_retry_attempts 必须大于等于 1。")
-
-        if update_options is not None:
-            self.update(update_options, target=update_target)
-            self.cleanup_remote_artifacts()
-
-        if extract_options is None and mapping_options is None:
-            return
-
-        work_items = self.build_work_items(
-            extract_options=extract_options,
-            mapping_options=mapping_options,
-            extract_include_champions=extract_include_champions,
-            extract_include_maps=extract_include_maps,
-            mapping_include_champions=mapping_include_champions,
-            mapping_include_maps=mapping_include_maps,
-        )
-        if not work_items:
-            logger.warning("remote 模式未生成任何实体工作项。")
-            return
-
-        total_work_items = len(work_items)
-        logger.info(f"remote 模式启用单位驱动执行，共 {total_work_items} 个实体工作项。")
-        reader = self._create_reader()
-        remote_preparer = RemotePreparer(ctx=self.ctx)
-
-        for index, work_item in enumerate(work_items, start=1):
-            logger.info(
-                "remote 单位进度 {}/{}: {} {} (extract={}, mapping={})",
-                index,
-                total_work_items,
-                work_item.entity_type,
-                work_item.entity_id,
-                work_item.need_extract,
-                work_item.need_mapping,
-            )
-
-            for entity_attempt in range(1, entity_retry_attempts + 1):
-                is_champion = work_item.entity_type == "champion"
-                entity_data = self._build_entity_data(
-                    reader,
-                    entity_type=work_item.entity_type,
-                    entity_id=work_item.entity_id,
-                )
-                champion_ids = (work_item.entity_id,) if is_champion else None
-                map_ids = (work_item.entity_id,) if not is_champion else None
-                try:
-                    self._prepare_entity_wads(
-                        remote_preparer,
-                        reader=reader,
-                        champion_ids=champion_ids,
-                        map_ids=map_ids,
-                        include_champions=is_champion,
-                        include_maps=not is_champion,
-                        need_extract=work_item.need_extract,
-                        need_mapping=work_item.need_mapping,
-                        download_retry_attempts=download_retry_attempts,
-                        work_item=work_item,
-                        entity_attempt=entity_attempt,
-                        entity_retry_attempts=entity_retry_attempts,
-                    )
-
-                    extract_output_paths: tuple[Path, ...] = ()
-                    mapping_output_path: Path | None = None
-                    if work_item.need_extract and extract_options is not None:
-                        self.extract(
-                            self._build_entity_options(
-                                extract_options,
-                                entity_type=work_item.entity_type,
-                                entity_id=work_item.entity_id,
-                            ),
-                            include_champions=is_champion,
-                            include_maps=not is_champion,
-                            prepare_remote=False,
-                        )
-                        extract_output_paths = self._resolve_audio_paths(entity_data)
-                    if work_item.need_mapping and mapping_options is not None:
-                        self.mapping(
-                            self._build_entity_options(
-                                mapping_options,
-                                entity_type=work_item.entity_type,
-                                entity_id=work_item.entity_id,
-                            ),
-                            include_champions=is_champion,
-                            include_maps=not is_champion,
-                            prepare_remote=False,
-                        )
-                        mapping_output_path = self._resolve_mapping_path(
-                            entity_type=work_item.entity_type,
-                            entity_id=work_item.entity_id,
-                            integrate_data=mapping_options.integrate_data,
-                        )
-                    if progress_callback is not None:
-                        operation_name = "解包/映射"
-                        if work_item.need_extract and not work_item.need_mapping:
-                            operation_name = "解包"
-                        elif work_item.need_mapping and not work_item.need_extract:
-                            operation_name = "映射"
-                        progress_callback(
-                            index,
-                            total_work_items,
-                            f"{entity_data.entity_name} {operation_name}完成",
-                        )
-                    if on_entity_complete is not None and (extract_output_paths or mapping_output_path is not None):
-                        on_entity_complete(
-                            RemoteEntityCallbackPayload(
-                                entity_type=work_item.entity_type,
-                                entity_id=work_item.entity_id,
-                                audio_output_paths=extract_output_paths,
-                                mapping_output_path=mapping_output_path,
-                            )
-                        )
-                    break
-                except Exception as exc:
-                    if entity_attempt >= entity_retry_attempts:
-                        self._raise_entity_failure(
-                            work_item=work_item,
-                            entity_retry_attempts=entity_retry_attempts,
-                            exc=exc,
-                        )
-                    logger.warning(
-                        "remote 实体 {} {} 执行失败，准备重试 {}/{}：{}",
-                        work_item.entity_type,
-                        work_item.entity_id,
-                        entity_attempt + 1,
-                        entity_retry_attempts,
-                        exc,
-                    )
-                finally:
-                    self.cleanup_remote_artifacts()
-
-        logger.success(f"remote 实体工作流完成：共处理 {total_work_items} 个实体工作项")
+    def run_workflow(self, **kwargs) -> None:
+        """按实体拆批执行 remote 流程（委托 RemoteWorkflowOrchestrator）。"""
+        self._remote_orchestrator().run_workflow(**kwargs)
 
     def update(self, opts: OperationOptions, *, target: str = "all") -> None:
         """执行更新流程。"""

--- a/src/lol_audio_unpack/app/remote_workflow.py
+++ b/src/lol_audio_unpack/app/remote_workflow.py
@@ -1,0 +1,443 @@
+"""远端快照模式的按实体拆批执行编排。
+
+从 ``LolAudioUnpackApp`` 抽出，专责 ``remote_snapshot`` 模式下的实体工作项构建、
+逐实体下载/解包/映射、失败重试与每轮清理。标准操作（update/extract/mapping/cleanup）、
+实体解析（构建实体数据、解析输出路径）以及读取器/远端准备器的构造均通过回调注入，
+避免反向依赖 facade，也让远端工作流可独立单测。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from riotmanifest import DecompressError, DownloadBatchError, DownloadError
+
+from .remote import RemoteEntityCallbackPayload, RemoteEntityWorkItem
+from .targets import iter_entity_refs
+from .types import AppContext, OperationOptions, SourceMode
+
+if TYPE_CHECKING:
+    from lol_audio_unpack.manager import DataReader
+    from lol_audio_unpack.model import AudioEntityData
+    from lol_audio_unpack.runtime.remote import RemotePreparer
+
+DEFAULT_DOWNLOAD_RETRIES = 3
+DEFAULT_ENTITY_RETRIES = 3
+
+
+class RemoteWorkflowOrchestrator:
+    """remote_snapshot 模式下按实体拆批执行的工作流编排器。"""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        ctx: AppContext,
+        *,
+        update_fn: Callable[..., None],
+        extract_fn: Callable[..., None],
+        mapping_fn: Callable[..., None],
+        cleanup_fn: Callable[[], None],
+        build_entity_data_fn: Callable[..., AudioEntityData],
+        resolve_audio_paths_fn: Callable[[AudioEntityData], tuple[Path, ...]],
+        resolve_mapping_path_fn: Callable[..., Path | None],
+        create_reader_fn: Callable[[], DataReader],
+        remote_preparer_factory: Callable[[], RemotePreparer],
+    ) -> None:
+        """初始化编排器。
+
+        Args:
+            ctx: 应用运行上下文。
+            update_fn: 标准 update 操作（签名同 ``LolAudioUnpackApp.update``）。
+            extract_fn: 标准 extract 操作（签名同 ``LolAudioUnpackApp.extract``）。
+            mapping_fn: 标准 mapping 操作（签名同 ``LolAudioUnpackApp.mapping``）。
+            cleanup_fn: 远端产物清理（签名同 ``cleanup_remote_artifacts``）。
+            build_entity_data_fn: 构建实体数据的回调。
+            resolve_audio_paths_fn: 解析实体解包输出目录的回调。
+            resolve_mapping_path_fn: 解析实体 mapping 产物路径的回调。
+            create_reader_fn: 构造数据读取器的回调。
+            remote_preparer_factory: 构造远端准备器的回调。
+        """
+        self.ctx = ctx
+        self._update = update_fn
+        self._extract = extract_fn
+        self._mapping = mapping_fn
+        self._cleanup = cleanup_fn
+        self._build_entity_data = build_entity_data_fn
+        self._resolve_audio_paths = resolve_audio_paths_fn
+        self._resolve_mapping_path = resolve_mapping_path_fn
+        self._create_reader = create_reader_fn
+        self._remote_preparer_factory = remote_preparer_factory
+
+    @staticmethod
+    def _merge_remote_work_item(
+        work_items: dict[tuple[str, int], RemoteEntityWorkItem],
+        *,
+        entity_type: str,
+        entity_id: int,
+        need_extract: bool,
+        need_mapping: bool,
+    ) -> None:
+        """注册或合并远端实体工作项。"""
+        key = (entity_type, entity_id)
+        existing = work_items.get(key)
+        if existing is None:
+            work_items[key] = RemoteEntityWorkItem(
+                entity_type=entity_type,
+                entity_id=entity_id,
+                need_extract=need_extract,
+                need_mapping=need_mapping,
+            )
+            return
+
+        work_items[key] = RemoteEntityWorkItem(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            need_extract=existing.need_extract or need_extract,
+            need_mapping=existing.need_mapping or need_mapping,
+        )
+
+    def _register_remote_work_items(  # noqa: PLR0913
+        self,
+        work_items: dict[tuple[str, int], RemoteEntityWorkItem],
+        *,
+        reader: DataReader,
+        opts: OperationOptions | None,
+        need_extract: bool,
+        need_mapping: bool,
+        include_champions: bool,
+        include_maps: bool,
+    ) -> None:
+        """根据操作范围生成远端实体工作项。"""
+        if opts is None:
+            return
+
+        for entity_type, entity_id in iter_entity_refs(
+            reader,
+            champion_ids=opts.champion_ids,
+            map_ids=opts.map_ids,
+            include_champions=include_champions,
+            include_maps=include_maps,
+        ):
+            self._merge_remote_work_item(
+                work_items,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                need_extract=need_extract,
+                need_mapping=need_mapping,
+            )
+
+    @staticmethod
+    def _build_entity_options(
+        opts: OperationOptions,
+        *,
+        entity_type: str,
+        entity_id: int,
+    ) -> OperationOptions:
+        """将批量操作选项收窄为单实体选项。"""
+        is_champion = entity_type == "champion"
+        return replace(
+            opts,
+            champion_ids=(entity_id,) if is_champion else None,
+            map_ids=(entity_id,) if not is_champion else None,
+        )
+
+    @staticmethod
+    def _is_retryable_download_error(exc: BaseException) -> bool:
+        """判断是否属于可重试的远端下载错误。"""
+        return isinstance(exc, (DownloadError, DecompressError, DownloadBatchError))
+
+    def _prepare_entity_wads(  # noqa: PLR0913
+        self,
+        remote_preparer: RemotePreparer,
+        *,
+        reader: DataReader,
+        champion_ids: tuple[int, ...] | None,
+        map_ids: tuple[int, ...] | None,
+        include_champions: bool,
+        include_maps: bool,
+        need_extract: bool,
+        need_mapping: bool,
+        download_retry_attempts: int,
+        work_item: RemoteEntityWorkItem,
+        entity_attempt: int,
+        entity_retry_attempts: int,
+    ) -> None:
+        """按下载错误重试准备单实体所需 WAD。"""
+        for download_attempt in range(1, download_retry_attempts + 1):
+            try:
+                remote_preparer.prepare_entity_wads(
+                    reader=reader,
+                    champion_ids=champion_ids,
+                    map_ids=map_ids,
+                    include_champions=include_champions,
+                    include_maps=include_maps,
+                    need_extract=need_extract,
+                    need_mapping=need_mapping,
+                )
+                return
+            except Exception as exc:
+                if not self._is_retryable_download_error(exc):
+                    raise
+                if download_attempt >= download_retry_attempts:
+                    raise
+                logger.warning(
+                    "remote 实体 {} {} 下载 WAD 失败，准备重试 {}/{}（实体重试 {}/{}）：{}",
+                    work_item.entity_type,
+                    work_item.entity_id,
+                    download_attempt + 1,
+                    download_retry_attempts,
+                    entity_attempt,
+                    entity_retry_attempts,
+                    exc,
+                )
+
+    def _raise_entity_failure(
+        self,
+        *,
+        work_item: RemoteEntityWorkItem,
+        entity_retry_attempts: int,
+        exc: Exception,
+    ) -> None:
+        """在实体重试耗尽后抛出带上下文的错误。"""
+        raise RuntimeError(
+            "remote 实体执行失败且已超过重试阈值："
+            f"{work_item.entity_type} {work_item.entity_id} 已尝试 {entity_retry_attempts} 次；"
+            "当前解包脚本可能无法正常解包，可能是网络持续异常、二进制文件版本更新或上游资源结构变化导致。"
+        ) from exc
+
+    def build_work_items(  # noqa: PLR0913
+        self,
+        *,
+        extract_options: OperationOptions | None = None,
+        mapping_options: OperationOptions | None = None,
+        extract_include_champions: bool = True,
+        extract_include_maps: bool = True,
+        mapping_include_champions: bool = True,
+        mapping_include_maps: bool = True,
+    ) -> list[RemoteEntityWorkItem]:
+        """构建 remote 模式下的实体工作项队列。
+
+        Args:
+            extract_options: extract 阶段的操作选项；为 ``None`` 表示不执行 extract。
+            mapping_options: mapping 阶段的操作选项；为 ``None`` 表示不执行 mapping。
+            extract_include_champions: extract 阶段是否包含英雄。
+            extract_include_maps: extract 阶段是否包含地图。
+            mapping_include_champions: mapping 阶段是否包含英雄。
+            mapping_include_maps: mapping 阶段是否包含地图。
+
+        Returns:
+            已按实体类型与 ID 排序的工作项列表。
+
+        Raises:
+            ValueError: 当前不是 ``remote_snapshot`` 模式。
+        """
+        if self.ctx.config.source_mode is not SourceMode.REMOTE_SNAPSHOT:
+            raise ValueError("仅 remote_snapshot 模式支持按实体拆批执行。")
+
+        reader = self._create_reader()
+        work_items: dict[tuple[str, int], RemoteEntityWorkItem] = {}
+        self._register_remote_work_items(
+            work_items,
+            reader=reader,
+            opts=extract_options,
+            need_extract=True,
+            need_mapping=False,
+            include_champions=extract_include_champions,
+            include_maps=extract_include_maps,
+        )
+        self._register_remote_work_items(
+            work_items,
+            reader=reader,
+            opts=mapping_options,
+            need_extract=False,
+            need_mapping=True,
+            include_champions=mapping_include_champions,
+            include_maps=mapping_include_maps,
+        )
+        return sorted(
+            work_items.values(),
+            key=lambda item: (item.entity_type != "champion", item.entity_id),
+        )
+
+    def run_workflow(  # noqa: PLR0913
+        self,
+        *,
+        update_options: OperationOptions | None = None,
+        update_target: str = "all",
+        extract_options: OperationOptions | None = None,
+        mapping_options: OperationOptions | None = None,
+        extract_include_champions: bool = True,
+        extract_include_maps: bool = True,
+        mapping_include_champions: bool = True,
+        mapping_include_maps: bool = True,
+        on_entity_complete: Callable[[RemoteEntityCallbackPayload], None] | None = None,
+        progress_callback: Callable[[int, int, str], None] | None = None,
+        download_retry_attempts: int = DEFAULT_DOWNLOAD_RETRIES,
+        entity_retry_attempts: int = DEFAULT_ENTITY_RETRIES,
+    ) -> None:
+        """按实体拆批执行 remote 流程，并在每轮后清理远端产物。
+
+        Args:
+            update_options: 可选的 update 选项；提供时会先执行一次全局 update。
+            update_target: update 阶段目标，语义与 ``update(..., target=...)`` 相同。
+            extract_options: extract 阶段的操作选项；为 ``None`` 表示跳过。
+            mapping_options: mapping 阶段的操作选项；为 ``None`` 表示跳过。
+            extract_include_champions: extract 阶段是否包含英雄。
+            extract_include_maps: extract 阶段是否包含地图。
+            mapping_include_champions: mapping 阶段是否包含英雄。
+            mapping_include_maps: mapping 阶段是否包含地图。
+            on_entity_complete: 当前实体执行完成后的可选回调。
+            progress_callback: 每个实体处理结束后的可选进度回调。
+            download_retry_attempts: 单次实体尝试内，WAD 下载类错误的最大重试次数。
+            entity_retry_attempts: 单实体完整流程失败时的最大重试次数。
+
+        Raises:
+            ValueError: 当前不是 ``remote_snapshot`` 模式。
+        """
+        if self.ctx.config.source_mode is not SourceMode.REMOTE_SNAPSHOT:
+            raise ValueError("仅 remote_snapshot 模式支持按实体拆批执行。")
+        if download_retry_attempts < 1:
+            raise ValueError("download_retry_attempts 必须大于等于 1。")
+        if entity_retry_attempts < 1:
+            raise ValueError("entity_retry_attempts 必须大于等于 1。")
+
+        if update_options is not None:
+            self._update(update_options, target=update_target)
+            self._cleanup()
+
+        if extract_options is None and mapping_options is None:
+            return
+
+        work_items = self.build_work_items(
+            extract_options=extract_options,
+            mapping_options=mapping_options,
+            extract_include_champions=extract_include_champions,
+            extract_include_maps=extract_include_maps,
+            mapping_include_champions=mapping_include_champions,
+            mapping_include_maps=mapping_include_maps,
+        )
+        if not work_items:
+            logger.warning("remote 模式未生成任何实体工作项。")
+            return
+
+        total_work_items = len(work_items)
+        logger.info(f"remote 模式启用单位驱动执行，共 {total_work_items} 个实体工作项。")
+        reader = self._create_reader()
+        remote_preparer = self._remote_preparer_factory()
+
+        for index, work_item in enumerate(work_items, start=1):
+            logger.info(
+                "remote 单位进度 {}/{}: {} {} (extract={}, mapping={})",
+                index,
+                total_work_items,
+                work_item.entity_type,
+                work_item.entity_id,
+                work_item.need_extract,
+                work_item.need_mapping,
+            )
+
+            for entity_attempt in range(1, entity_retry_attempts + 1):
+                is_champion = work_item.entity_type == "champion"
+                entity_data = self._build_entity_data(
+                    reader,
+                    entity_type=work_item.entity_type,
+                    entity_id=work_item.entity_id,
+                )
+                champion_ids = (work_item.entity_id,) if is_champion else None
+                map_ids = (work_item.entity_id,) if not is_champion else None
+                try:
+                    self._prepare_entity_wads(
+                        remote_preparer,
+                        reader=reader,
+                        champion_ids=champion_ids,
+                        map_ids=map_ids,
+                        include_champions=is_champion,
+                        include_maps=not is_champion,
+                        need_extract=work_item.need_extract,
+                        need_mapping=work_item.need_mapping,
+                        download_retry_attempts=download_retry_attempts,
+                        work_item=work_item,
+                        entity_attempt=entity_attempt,
+                        entity_retry_attempts=entity_retry_attempts,
+                    )
+
+                    extract_output_paths: tuple[Path, ...] = ()
+                    mapping_output_path: Path | None = None
+                    if work_item.need_extract and extract_options is not None:
+                        self._extract(
+                            self._build_entity_options(
+                                extract_options,
+                                entity_type=work_item.entity_type,
+                                entity_id=work_item.entity_id,
+                            ),
+                            include_champions=is_champion,
+                            include_maps=not is_champion,
+                            prepare_remote=False,
+                        )
+                        extract_output_paths = self._resolve_audio_paths(entity_data)
+                    if work_item.need_mapping and mapping_options is not None:
+                        self._mapping(
+                            self._build_entity_options(
+                                mapping_options,
+                                entity_type=work_item.entity_type,
+                                entity_id=work_item.entity_id,
+                            ),
+                            include_champions=is_champion,
+                            include_maps=not is_champion,
+                            prepare_remote=False,
+                        )
+                        mapping_output_path = self._resolve_mapping_path(
+                            entity_type=work_item.entity_type,
+                            entity_id=work_item.entity_id,
+                            integrate_data=mapping_options.integrate_data,
+                        )
+                    if progress_callback is not None:
+                        operation_name = "解包/映射"
+                        if work_item.need_extract and not work_item.need_mapping:
+                            operation_name = "解包"
+                        elif work_item.need_mapping and not work_item.need_extract:
+                            operation_name = "映射"
+                        progress_callback(
+                            index,
+                            total_work_items,
+                            f"{entity_data.entity_name} {operation_name}完成",
+                        )
+                    if on_entity_complete is not None and (extract_output_paths or mapping_output_path is not None):
+                        on_entity_complete(
+                            RemoteEntityCallbackPayload(
+                                entity_type=work_item.entity_type,
+                                entity_id=work_item.entity_id,
+                                audio_output_paths=extract_output_paths,
+                                mapping_output_path=mapping_output_path,
+                            )
+                        )
+                    break
+                except Exception as exc:
+                    if entity_attempt >= entity_retry_attempts:
+                        self._raise_entity_failure(
+                            work_item=work_item,
+                            entity_retry_attempts=entity_retry_attempts,
+                            exc=exc,
+                        )
+                    logger.warning(
+                        "remote 实体 {} {} 执行失败，准备重试 {}/{}：{}",
+                        work_item.entity_type,
+                        work_item.entity_id,
+                        entity_attempt + 1,
+                        entity_retry_attempts,
+                        exc,
+                    )
+                finally:
+                    self._cleanup()
+
+        logger.success(f"remote 实体工作流完成：共处理 {total_work_items} 个实体工作项")
+
+
+__all__ = [
+    "DEFAULT_DOWNLOAD_RETRIES",
+    "DEFAULT_ENTITY_RETRIES",
+    "RemoteWorkflowOrchestrator",
+]

--- a/src/lol_audio_unpack/manager/bin_source.py
+++ b/src/lol_audio_unpack/manager/bin_source.py
@@ -1,0 +1,218 @@
+"""BIN 来源选择与基础数据构建辅助。
+
+该模块负责按优先级从 WAD 或本地 BIN 输入目录提取 BIN 二进制数据，
+并统一加载地图 BIN、生成带标准元数据的基础数据结构。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from league_tools.formats import BIN, WAD
+from loguru import logger
+
+from lol_audio_unpack.manager.utils import build_metadata_payload
+
+if TYPE_CHECKING:
+    from lol_audio_unpack.app.types import AppContext
+
+
+class BinSource:
+    """承载 BIN 提取/加载与基础数据构建职责。
+
+    将 BIN 来源（WAD 优先、本地 BIN 回退）的解析逻辑集中在此，
+    供英雄/地图处理器复用。
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        ctx: AppContext,
+        game_path: Path,
+        version: str,
+        local_bin_input_dir: Path,
+        use_local_bin_flag_file: Path,
+        languages: list[str] | None = None,
+    ):
+        """初始化 BIN 来源。
+
+        :param ctx: 运行时上下文。
+        :param game_path: 游戏客户端根目录。
+        :param version: 当前游戏版本。
+        :param local_bin_input_dir: 本地 BIN 输入目录。
+        :param use_local_bin_flag_file: 本地 BIN 模式标志文件路径。
+        :param languages: 元数据语言列表，在 update() 中初始化。
+        """
+        self.ctx = ctx
+        self.game_path = game_path
+        self.version = version
+        self.local_bin_input_dir = local_bin_input_dir
+        self.use_local_bin_flag_file = use_local_bin_flag_file
+        self.languages: list[str] = languages if languages is not None else []
+
+    def _is_dev_mode(self) -> bool:
+        """返回当前运行是否为开发模式。"""
+        return bool(self.ctx.config.dev_mode)
+
+    def _is_local_bin_mode_enabled(self) -> bool:
+        """
+        检查是否启用了本地 BIN 输入模式。
+
+        :returns: 启用返回 True，否则返回 False。
+        """
+        return self.use_local_bin_flag_file.exists()
+
+    def _build_local_bin_path(self, bin_path: str) -> Path:
+        """
+        将 binPath 转换为本地 BIN 文件绝对路径，并阻止路径逃逸。
+
+        :param bin_path: 数据文件中的相对 BIN 路径。
+        :returns: 本地 BIN 文件绝对路径。
+        :raises ValueError: 当路径越界时抛出。
+        """
+        local_root = self.local_bin_input_dir.resolve()
+        candidate = (self.local_bin_input_dir / Path(bin_path)).resolve()
+        try:
+            candidate.relative_to(local_root)
+        except ValueError as e:
+            raise ValueError(f"检测到越界 binPath，拒绝读取: {bin_path}") from e
+        return candidate
+
+    def _extract_bin_raws(
+        self,
+        wad_path: Path | None,
+        bin_paths: list[str],
+        entity_label: str,
+        local_required_dir: Path | None = None,
+    ) -> list[bytes | None]:
+        """
+        按优先级提取 BIN 二进制数据。
+
+        优先级:
+        1) WAD 文件存在时，强制走 WAD 提取。
+        2) WAD 不存在时，若存在 `.use_local_bin` 标志，则走本地目录读取。
+        3) 其余情况返回空结果。
+
+        :param wad_path: 待提取的 WAD 路径；为空表示无可用 WAD 信息。
+        :param bin_paths: 目标 BIN 路径列表。
+        :param entity_label: 实体标签（用于日志）。
+        :param local_required_dir: 本地模式下要求存在的目录（相对于 `bin_input`）。
+        :returns: 与 `bin_paths` 顺序一致的二进制数组，缺失项为 ``None``。
+        :raises FileNotFoundError: 本地模式开启但目录缺失时抛出。
+        :raises ValueError: 当路径越界时抛出。
+        """
+        if not bin_paths:
+            return []
+
+        if wad_path and wad_path.exists():
+            logger.trace(f"{entity_label} 使用 WAD 读取 BIN: {wad_path}")
+            return WAD(wad_path).extract(bin_paths, raw=True)
+
+        if not self._is_local_bin_mode_enabled():
+            if wad_path:
+                logger.warning(f"{entity_label} 的WAD文件不存在，且未启用本地BIN模式: {wad_path}")
+            else:
+                logger.warning(f"{entity_label} 缺少WAD路径信息，且未启用本地BIN模式")
+            return []
+
+        if wad_path:
+            logger.debug(f"{entity_label} 的WAD文件不可用，回退到本地BIN模式: {wad_path}")
+        else:
+            logger.debug(f"{entity_label} 缺少WAD路径信息，回退到本地BIN模式")
+
+        if not self.local_bin_input_dir.exists():
+            raise FileNotFoundError(f"{entity_label} 启用了本地BIN模式，但目录不存在: {self.local_bin_input_dir}")
+
+        if local_required_dir is not None:
+            required_path = self.local_bin_input_dir / local_required_dir
+            if not required_path.exists():
+                raise FileNotFoundError(f"{entity_label} 本地BIN实体目录不存在: {required_path}")
+
+        bin_raws: list[bytes | None] = []
+        missing_count = 0
+        for bin_path in bin_paths:
+            local_bin_file = self._build_local_bin_path(bin_path)
+            if not local_bin_file.is_file():
+                bin_raws.append(None)
+                missing_count += 1
+                continue
+
+            file_data = local_bin_file.read_bytes()
+            if not file_data:
+                bin_raws.append(None)
+                missing_count += 1
+                continue
+            bin_raws.append(file_data)
+
+        if missing_count > 0:
+            logger.debug(f"{entity_label} 本地BIN存在缺失或空文件，已按缺失处理: {missing_count}/{len(bin_paths)}")
+
+        logger.trace(f"{entity_label} 使用本地BIN目录读取: {self.local_bin_input_dir}")
+        return bin_raws
+
+    def _load_map_bin_file(self, map_id: str, map_data: dict) -> BIN | None:
+        """
+        统一加载地图 BIN 文件，兼容 WAD 与本地 BIN 模式。
+
+        :param map_id: 地图ID。
+        :param map_data: 地图数据字典。
+        :returns: BIN 对象；失败时返回 None。
+        """
+        bin_path = map_data.get("binPath")
+        if not bin_path:
+            return None
+
+        wad_root = map_data.get("wad", {}).get("root")
+        wad_path = self.game_path / wad_root if wad_root else None
+        local_required_dir = Path(bin_path).parent
+
+        try:
+            bin_raws = self._extract_bin_raws(
+                wad_path=wad_path,
+                bin_paths=[bin_path],
+                entity_label=f"地图 {map_id}",
+                local_required_dir=local_required_dir,
+            )
+            if not bin_raws:
+                return None
+            bin_raw = bin_raws[0]
+            if not bin_raw:
+                return None
+            return BIN(bin_raw)
+        except (FileNotFoundError, ValueError):
+            logger.opt(exception=True).error(f"提取或解析地图 {map_id} 的本地BIN文件时出错")
+        except Exception:
+            logger.opt(exception=True).error(f"提取或解析地图 {map_id} 的BIN文件时出错")
+            if self._is_dev_mode():
+                raise
+        return None
+
+    def _create_base_data(self, entity_id: str, entity_type: str, **extra_fields) -> dict:
+        """
+        创建包含元数据和实体特定信息的基础数据结构。
+
+        :param entity_id: 实体ID（英雄ID或地图ID）
+        :param entity_type: 实体类型（'champion' 或 'map'）
+        :param extra_fields: 任何要添加到顶层的额外字段
+        :return: 包含元数据和附加字段的基础字典
+        """
+        # 使用通用函数创建包含所有标准元数据的对象
+        base_data = build_metadata_payload(self.version, self.languages)
+
+        # 检查是否为事件文件（通过是否存在'skins'或'map'顶级键来判断）
+        is_event_file = "skins" in extra_fields or "map" in extra_fields
+
+        # 如果是事件文件，则从中移除 'languages' 字段
+        if is_event_file and "metadata" in base_data and "languages" in base_data["metadata"]:
+            del base_data["metadata"]["languages"]
+
+        # 添加实体特定ID
+        if entity_type == "champion":
+            base_data["championId"] = entity_id
+        elif entity_type == "map":
+            base_data["mapId"] = entity_id
+
+        # 合并任何其他的附加字段
+        base_data.update(extra_fields)
+        return base_data

--- a/src/lol_audio_unpack/manager/bin_updater.py
+++ b/src/lol_audio_unpack/manager/bin_updater.py
@@ -6,25 +6,21 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from league_tools.formats import BIN, WAD
 from loguru import logger
 
 from lol_audio_unpack.app.game_version import resolve_game_version
-from lol_audio_unpack.manager.files import needs_update, read_data, write_data
-from lol_audio_unpack.manager.utils import build_metadata_payload
+from lol_audio_unpack.manager.bin_source import BinSource
+from lol_audio_unpack.manager.champion_bin_processor import ChampionBinProcessor
+from lol_audio_unpack.manager.files import read_data
+from lol_audio_unpack.manager.map_bin_processor import MapBinProcessor
 from lol_audio_unpack.utils.logging import performance_monitor
 from lol_audio_unpack.utils.run_summary import record_runtime_note
 
 if TYPE_CHECKING:
     from lol_audio_unpack.app.types import AppContext
-
-# 类型别名定义
-ChampionData = dict[str, Any]
-CommonEventSourceIndex = dict[str, set[str]]
 
 
 class BinUpdater:
@@ -68,13 +64,39 @@ class BinUpdater:
         self.map_events_dir: Path = self.version_manifest_path / "events" / "maps"
         self.languages: list[str] = []  # 在update()中初始化
 
+        # 拆分后的协作对象：BIN 来源 + 英雄/地图处理器
+        self.bin_source = BinSource(
+            ctx=self.ctx,
+            game_path=self.game_path,
+            version=self.version,
+            local_bin_input_dir=self.local_bin_input_dir,
+            use_local_bin_flag_file=self.use_local_bin_flag_file,
+            languages=self.languages,
+        )
+        self._champion_processor = ChampionBinProcessor(
+            self.bin_source,
+            ctx=self.ctx,
+            version=self.version,
+            force_update=self.force_update,
+            process_events=self.process_events,
+            game_path=self.game_path,
+            champion_banks_dir=self.champion_banks_dir,
+            champion_events_dir=self.champion_events_dir,
+        )
+        self._map_processor = MapBinProcessor(
+            self.bin_source,
+            ctx=self.ctx,
+            version=self.version,
+            force_update=self.force_update,
+            process_events=self.process_events,
+            map_banks_dir=self.map_banks_dir,
+            map_events_dir=self.map_events_dir,
+            languages=self.languages,
+        )
+
     def _is_dev_mode(self) -> bool:
         """返回当前运行是否为开发模式。"""
         return bool(self.ctx.config.dev_mode)
-
-    def _log_simple_progress(self, stage_name: str, index: int, total: int, entity_id: str) -> None:
-        """输出简单的批量处理进度日志。"""
-        logger.info(f"{stage_name}进度 {index}/{total}: {entity_id}")
 
     @logger.catch
     @performance_monitor(level="INFO")
@@ -97,7 +119,10 @@ class BinUpdater:
             raise FileNotFoundError(f"数据文件不存在: {self.data_file_base}")
 
         self.languages = data.get("metadata", {}).get("languages", [])
-        local_bin_mode_enabled = self._is_local_bin_mode_enabled()
+        # 将运行期解析出的语言列表同步给协作对象
+        self.bin_source.languages = self.languages
+        self._map_processor.languages = self.languages
+        local_bin_mode_enabled = self.bin_source._is_local_bin_mode_enabled()
 
         # 根据传入的IDs构建筛选后的数据
         if champion_ids or map_ids:
@@ -111,10 +136,10 @@ class BinUpdater:
                 f"本地BIN模式={'开启' if local_bin_mode_enabled else '关闭'}"
             )
             if champion_ids and filtered_data.get("champions"):
-                self._update_champions(filtered_data)
+                self._champion_processor._update_champions(filtered_data)
             if map_ids and filtered_data.get("maps"):
                 self._record_map_event_scope_note(map_ids)
-                self._update_maps(filtered_data)
+                self._map_processor._update_maps(filtered_data)
             logger.success(f"BinUpdater 更新完成（精确模式）：英雄 {champion_count} 个，地图 {map_count} 个")
         else:
             # 批量模式：使用target控制
@@ -126,9 +151,9 @@ class BinUpdater:
                 f"本地BIN模式={'开启' if local_bin_mode_enabled else '关闭'}"
             )
             if target in ["skin", "all"]:
-                self._update_champions(data)
+                self._champion_processor._update_champions(data)
             if target in ["map", "all"]:
-                self._update_maps(data)
+                self._map_processor._update_maps(data)
             logger.success(f"BinUpdater 更新完成（批量模式）：英雄 {champion_count} 个，地图 {map_count} 个")
 
     def _record_map_event_scope_note(self, map_ids: list[str]) -> None:
@@ -144,102 +169,6 @@ class BinUpdater:
         detail = f"精确地图更新目标: {normalized_ids}；由于未包含地图 0，Common 事件差量规则不会参与本次运行。"
         record_runtime_note(self.ctx.runtime_cache, "update", message, label="数据更新", detail=detail)
 
-    def _is_local_bin_mode_enabled(self) -> bool:
-        """
-        检查是否启用了本地 BIN 输入模式。
-
-        :returns: 启用返回 True，否则返回 False。
-        """
-        return self.use_local_bin_flag_file.exists()
-
-    def _build_local_bin_path(self, bin_path: str) -> Path:
-        """
-        将 binPath 转换为本地 BIN 文件绝对路径，并阻止路径逃逸。
-
-        :param bin_path: 数据文件中的相对 BIN 路径。
-        :returns: 本地 BIN 文件绝对路径。
-        :raises ValueError: 当路径越界时抛出。
-        """
-        local_root = self.local_bin_input_dir.resolve()
-        candidate = (self.local_bin_input_dir / Path(bin_path)).resolve()
-        try:
-            candidate.relative_to(local_root)
-        except ValueError as e:
-            raise ValueError(f"检测到越界 binPath，拒绝读取: {bin_path}") from e
-        return candidate
-
-    def _extract_bin_raws(
-        self,
-        wad_path: Path | None,
-        bin_paths: list[str],
-        entity_label: str,
-        local_required_dir: Path | None = None,
-    ) -> list[bytes | None]:
-        """
-        按优先级提取 BIN 二进制数据。
-
-        优先级:
-        1) WAD 文件存在时，强制走 WAD 提取。
-        2) WAD 不存在时，若存在 `.use_local_bin` 标志，则走本地目录读取。
-        3) 其余情况返回空结果。
-
-        :param wad_path: 待提取的 WAD 路径；为空表示无可用 WAD 信息。
-        :param bin_paths: 目标 BIN 路径列表。
-        :param entity_label: 实体标签（用于日志）。
-        :param local_required_dir: 本地模式下要求存在的目录（相对于 `bin_input`）。
-        :returns: 与 `bin_paths` 顺序一致的二进制数组，缺失项为 ``None``。
-        :raises FileNotFoundError: 本地模式开启但目录缺失时抛出。
-        :raises ValueError: 当路径越界时抛出。
-        """
-        if not bin_paths:
-            return []
-
-        if wad_path and wad_path.exists():
-            logger.trace(f"{entity_label} 使用 WAD 读取 BIN: {wad_path}")
-            return WAD(wad_path).extract(bin_paths, raw=True)
-
-        if not self._is_local_bin_mode_enabled():
-            if wad_path:
-                logger.warning(f"{entity_label} 的WAD文件不存在，且未启用本地BIN模式: {wad_path}")
-            else:
-                logger.warning(f"{entity_label} 缺少WAD路径信息，且未启用本地BIN模式")
-            return []
-
-        if wad_path:
-            logger.debug(f"{entity_label} 的WAD文件不可用，回退到本地BIN模式: {wad_path}")
-        else:
-            logger.debug(f"{entity_label} 缺少WAD路径信息，回退到本地BIN模式")
-
-        if not self.local_bin_input_dir.exists():
-            raise FileNotFoundError(f"{entity_label} 启用了本地BIN模式，但目录不存在: {self.local_bin_input_dir}")
-
-        if local_required_dir is not None:
-            required_path = self.local_bin_input_dir / local_required_dir
-            if not required_path.exists():
-                raise FileNotFoundError(f"{entity_label} 本地BIN实体目录不存在: {required_path}")
-
-        bin_raws: list[bytes | None] = []
-        missing_count = 0
-        for bin_path in bin_paths:
-            local_bin_file = self._build_local_bin_path(bin_path)
-            if not local_bin_file.is_file():
-                bin_raws.append(None)
-                missing_count += 1
-                continue
-
-            file_data = local_bin_file.read_bytes()
-            if not file_data:
-                bin_raws.append(None)
-                missing_count += 1
-                continue
-            bin_raws.append(file_data)
-
-        if missing_count > 0:
-            logger.debug(f"{entity_label} 本地BIN存在缺失或空文件，已按缺失处理: {missing_count}/{len(bin_paths)}")
-
-        logger.trace(f"{entity_label} 使用本地BIN目录读取: {self.local_bin_input_dir}")
-        return bin_raws
-
     def _filter_data_by_ids(self, data: dict, champion_ids: list[str] | None, map_ids: list[str] | None) -> dict:
         """
         根据指定的ID列表筛选数据
@@ -249,8 +178,7 @@ class BinUpdater:
         :param map_ids: 要筛选的地图ID列表
         :returns: 筛选后的数据字典，保持原有结构
         """
-        filtered_data = {
-            "languages": data.get("languages", []),
+        filtered_data: dict = {
             # 其他基础字段保持不变
         }
 
@@ -279,633 +207,3 @@ class BinUpdater:
                 filtered_data["maps"] = filtered_maps
 
         return filtered_data
-
-    @performance_monitor(level="DEBUG")
-    def _update_champions(self, data: dict) -> None:
-        """
-        处理英雄数据，按英雄ID分别生成文件
-
-        :param data: 包含英雄数据的字典
-        """
-        logger.info("开始处理英雄音频数据...")
-        self.champion_banks_dir.mkdir(parents=True, exist_ok=True)
-        self.champion_events_dir.mkdir(parents=True, exist_ok=True)
-
-        champions = data.get("champions", {})
-        sorted_champion_ids = sorted(champions.keys(), key=int)
-
-        total_champions = len(sorted_champion_ids)
-        for index, champion_id in enumerate(sorted_champion_ids, start=1):
-            champion_data = champions[champion_id]
-            self._log_simple_progress("处理英雄", index, total_champions, champion_id)
-            self._process_champion_skins(champion_data, champion_id)
-
-        logger.success(f"英雄Banks数据更新完成，共处理 {total_champions} 个英雄")
-
-    @performance_monitor(level="DEBUG")
-    def _update_maps(self, data: dict) -> None:
-        """
-        处理地图数据，按地图ID分别生成文件
-
-        :param data: 包含地图数据的字典
-        """
-        logger.info("开始处理地图音频数据...")
-        self.map_banks_dir.mkdir(parents=True, exist_ok=True)
-        self.map_events_dir.mkdir(parents=True, exist_ok=True)
-
-        maps = data.get("maps", {})
-
-        # 预处理公共地图(ID 0)的事件数据和Banks数据
-        common_event_sources: CommonEventSourceIndex = {}
-        common_banks_set = set()
-        if "0" in maps:
-            logger.debug("正在预处理公共地图(ID 0)的数据...")
-            try:
-                # 预处理事件数据
-                if map_events := self._process_map_events_for_id("0", maps["0"]):
-                    if "events" in map_events:
-                        for category, events_list in map_events["events"].items():
-                            for event_string in events_list:
-                                common_event_sources.setdefault(event_string, set()).add(f"地图 0/{category}")
-
-                # 预处理Banks数据
-                if map_banks := self._process_map_banks_for_id("0", maps["0"]):
-                    if "banks" in map_banks:
-                        for paths_list in map_banks["banks"].values():
-                            for path in paths_list:
-                                common_banks_set.add(tuple(sorted(path)))
-            except Exception:
-                logger.opt(exception=True).error("预处理公共地图(ID 0)的数据时出错")
-                if self._is_dev_mode():
-                    raise
-
-        map_items = list(maps.items())
-        total_maps = len(map_items)
-        for index, (map_id, map_data) in enumerate(map_items, start=1):
-            self._log_simple_progress("处理地图", index, total_maps, map_id)
-            self._process_single_map(map_id, map_data, common_event_sources, common_banks_set)
-
-        logger.success(f"地图Banks数据更新完成，共处理 {total_maps} 个地图")
-
-    @performance_monitor(level="DEBUG")
-    def _process_champion_skins(self, champion_data: ChampionData, champion_id: str) -> None:
-        """
-        处理单个英雄的所有皮肤，提取音频数据并生成独立文件
-
-        :param champion_data: 英雄数据字典
-        :param champion_id: 英雄ID
-        """
-        alias_raw = champion_data.get("alias", "")
-        alias = alias_raw.lower()
-        if not alias:
-            return
-
-        # 检查是否需要更新
-        banks_file_base = self.champion_banks_dir / champion_id
-        events_file_base = self.champion_events_dir / champion_id
-
-        if not needs_update(
-            banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()
-        ) and not needs_update(events_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
-            logger.trace(f"英雄 {champion_id} ({alias}) 的数据已是最新，跳过处理")
-            return
-
-        path_to_skin_id_map: dict[str, str] = {}
-        skins_data = champion_data.get("skins", [])
-        sorted_skins_data = sorted(skins_data, key=lambda s: int(s["id"]))
-
-        base_skin_id = None
-        for skin in sorted_skins_data:
-            skin_id_str = str(skin["id"])
-            if skin.get("isBase"):
-                base_skin_id = skin_id_str
-
-            if bin_path := skin.get("binPath"):
-                path_to_skin_id_map[bin_path] = skin_id_str
-            for chroma in skin.get("chromas", []):
-                chroma_id_str = str(chroma["id"])
-                if bin_path := chroma.get("binPath"):
-                    path_to_skin_id_map[bin_path] = chroma_id_str
-
-        if not path_to_skin_id_map:
-            return
-
-        bin_paths = list(path_to_skin_id_map.keys())
-        root_wad_path = champion_data.get("wad", {}).get("root")
-        full_wad_path = self.game_path / root_wad_path if root_wad_path else None
-        local_required_dir = Path("data") / "characters" / alias_raw
-        try:
-            logger.trace(f"从 {alias} 提取 {len(bin_paths)} 个BIN文件")
-            bin_raws = self._extract_bin_raws(
-                wad_path=full_wad_path,
-                bin_paths=bin_paths,
-                entity_label=f"英雄 {champion_id} ({alias})",
-                local_required_dir=local_required_dir,
-            )
-            if not bin_raws or not bin_raws[0]:
-                logger.warning(f"英雄 {champion_id} ({alias}) 的首个BIN缺失或为空，跳过处理")
-                return
-            raw_data_map = dict(zip(bin_paths, bin_raws, strict=False))
-        except (FileNotFoundError, ValueError):
-            logger.opt(exception=True).error(f"处理英雄 {alias} 的本地BIN时出错")
-            return
-        except Exception:
-            logger.opt(exception=True).error(f"处理英雄 {alias} 的WAD文件时出错")
-            return
-
-        skin_ids_sorted = sorted(path_to_skin_id_map.values(), key=int)
-        path_to_id_reversed = {v: k for k, v in path_to_skin_id_map.items()}
-
-        # 初始化英雄的banks和events数据
-        champion_banks_data = self._create_base_data(
-            champion_id, "champion", alias=alias, skinAudioMappings={}, skins={}
-        )
-
-        champion_skin_events = {}
-        bank_path_to_owner_map: dict[tuple, str] = {}
-
-        for skin_id in skin_ids_sorted:
-            path = path_to_id_reversed[skin_id]
-            if not (bin_raw := raw_data_map.get(path)):
-                continue
-
-            try:
-                bin_file = BIN(bin_raw)
-                is_new_skin_entry = True
-
-                for group in bin_file.data:
-                    for event_data in group.bank_units:
-                        if event_data.bank_path:
-                            bank_path_fingerprint = tuple(sorted(event_data.bank_path))
-                            category = event_data.category
-
-                            if owner_id := bank_path_to_owner_map.get(bank_path_fingerprint):
-                                if skin_id != owner_id and "_Base_" not in category:
-                                    if skin_id not in champion_banks_data["skinAudioMappings"]:
-                                        champion_banks_data["skinAudioMappings"][skin_id] = {}
-                                    champion_banks_data["skinAudioMappings"][skin_id][category] = owner_id
-                            else:
-                                bank_path_to_owner_map[bank_path_fingerprint] = skin_id
-                                if skin_id not in champion_banks_data["skins"]:
-                                    champion_banks_data["skins"][skin_id] = {}
-                                if category not in champion_banks_data["skins"][skin_id]:
-                                    champion_banks_data["skins"][skin_id][category] = []
-                                champion_banks_data["skins"][skin_id][category].append(event_data.bank_path)
-
-                                if is_new_skin_entry and self.process_events:
-                                    if skin_events := self._extract_skin_events(bin_file, base_skin_id, skin_id):
-                                        champion_skin_events[skin_id] = skin_events
-                                    is_new_skin_entry = False
-
-            except Exception:
-                logger.opt(exception=True).error(f"解析皮肤BIN失败: {path}")
-                if self._is_dev_mode():
-                    raise
-
-        # 优化映射关系
-        self._optimize_champion_mappings(champion_banks_data)
-
-        # 写入banks数据
-        if needs_update(banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
-            write_data(champion_banks_data, banks_file_base, dev_mode=self._is_dev_mode())
-
-        # 写入events数据
-        if champion_skin_events and needs_update(
-            events_file_base,
-            self.version,
-            self.force_update,
-            dev_mode=self._is_dev_mode(),
-        ):
-            final_event_data = self._create_base_data(champion_id, "champion", alias=alias, skins=champion_skin_events)
-            write_data(final_event_data, events_file_base, dev_mode=self._is_dev_mode())
-
-    def _process_single_map(
-        self,
-        map_id: str,
-        map_data: dict,
-        common_event_sources: CommonEventSourceIndex | None = None,
-        common_banks_set: set | None = None,
-    ) -> None:
-        """
-        处理单个地图的Banks和Events数据
-
-        :param map_id: 地图ID
-        :param map_data: 地图数据字典
-        :param common_event_sources: 公共事件来源索引，用于事件去重和总结
-        :param common_banks_set: 公共Banks集合，用于去重
-        """
-        banks_file_base = self.map_banks_dir / map_id
-        events_file_base = self.map_events_dir / map_id
-
-        if not needs_update(
-            banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()
-        ) and not needs_update(events_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
-            logger.trace(f"地图 {map_id} 的数据已是最新，跳过处理")
-            return
-
-        if not map_data.get("binPath"):
-            return
-
-        bin_file = self._load_map_bin_file(map_id, map_data)
-        if bin_file is None:
-            return
-
-        # 处理Banks数据
-        map_banks = {}
-        for group in bin_file.data:
-            for event_data in group.bank_units:
-                if event_data.bank_path:
-                    category = event_data.category
-                    if category not in map_banks:
-                        map_banks[category] = []
-                    map_banks[category].append(event_data.bank_path)
-
-        # 去重处理
-        for category, paths in map_banks.items():
-            unique_paths_tuples = dict.fromkeys(tuple(sorted(p)) for p in paths)
-            map_banks[category] = [list(p) for p in unique_paths_tuples]
-
-        # 写入Banks数据
-        if map_banks and needs_update(banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
-            map_banks_data = self._create_base_data(map_id, "map", name=self._get_map_name(map_data), banks=map_banks)
-
-            # 对非公共地图进行去重处理
-            if map_id != "0" and common_banks_set:
-                self._deduplicate_single_map_banks(map_banks_data, common_banks_set)
-
-            # 去重后检查是否还有数据需要写入
-            if map_banks_data.get("banks"):
-                write_data(map_banks_data, banks_file_base, dev_mode=self._is_dev_mode())
-            else:
-                logger.trace(f"地图 {map_id} 去重后无独有Banks数据，跳过写入")
-
-        # 处理Events数据，只有在启用事件处理时才提取
-        if self.process_events and needs_update(
-            events_file_base,
-            self.version,
-            self.force_update,
-            dev_mode=self._is_dev_mode(),
-        ):
-            map_events, dedup_summary = self._extract_map_events(
-                bin_file,
-                common_event_sources if map_id != "0" else None,
-            )
-            if dedup_summary:
-                self._record_map_event_dedup_summary(map_id, map_data, dedup_summary)
-            if map_events:
-                final_event_data = self._create_base_data(
-                    map_id, "map", name=self._get_map_name(map_data), map=map_events
-                )
-                write_data(final_event_data, events_file_base, dev_mode=self._is_dev_mode())
-
-    def _load_map_bin_file(self, map_id: str, map_data: dict) -> BIN | None:
-        """
-        统一加载地图 BIN 文件，兼容 WAD 与本地 BIN 模式。
-
-        :param map_id: 地图ID。
-        :param map_data: 地图数据字典。
-        :returns: BIN 对象；失败时返回 None。
-        """
-        bin_path = map_data.get("binPath")
-        if not bin_path:
-            return None
-
-        wad_root = map_data.get("wad", {}).get("root")
-        wad_path = self.game_path / wad_root if wad_root else None
-        local_required_dir = Path(bin_path).parent
-
-        try:
-            bin_raws = self._extract_bin_raws(
-                wad_path=wad_path,
-                bin_paths=[bin_path],
-                entity_label=f"地图 {map_id}",
-                local_required_dir=local_required_dir,
-            )
-            if not bin_raws:
-                return None
-            bin_raw = bin_raws[0]
-            if not bin_raw:
-                return None
-            return BIN(bin_raw)
-        except (FileNotFoundError, ValueError):
-            logger.opt(exception=True).error(f"提取或解析地图 {map_id} 的本地BIN文件时出错")
-        except Exception:
-            logger.opt(exception=True).error(f"提取或解析地图 {map_id} 的BIN文件时出错")
-            if self._is_dev_mode():
-                raise
-        return None
-
-    def _extract_skin_events(self, bin_file: BIN, base_skin_id: str | None, current_skin_id: str) -> dict | None:
-        """
-        提取一个皮肤BIN文件中的所有事件数据
-
-        :param bin_file: BIN文件对象
-        :param base_skin_id: 基础皮肤ID，用于过滤基础皮肤事件
-        :param current_skin_id: 当前皮肤ID
-        :returns: 皮肤事件数据字典，无数据时返回None
-        """
-        skin_events = {}
-        if bin_file.theme_music:
-            skin_events["theme_music"] = bin_file.theme_music
-
-        all_events_by_category = {}
-        for group in bin_file.data:
-            if group.music:
-                skin_events["music"] = group.music.to_dict()
-            for event_data in group.bank_units:
-                if base_skin_id and current_skin_id != base_skin_id and "_Base_" in event_data.category:
-                    continue
-                if event_data.events:
-                    category = event_data.category
-                    if category not in all_events_by_category:
-                        all_events_by_category[category] = []
-                    event_strings = [e.string for e in event_data.events]
-                    # 添加到category，稍后统一去重
-                    all_events_by_category[category].extend(event_strings)
-
-        if all_events_by_category:
-            # 对每个category的事件列表进行去重
-            for category, events_list in all_events_by_category.items():
-                all_events_by_category[category] = list(dict.fromkeys(events_list))  # 保持顺序的去重
-            skin_events["events"] = all_events_by_category
-
-        return skin_events if skin_events else None
-
-    def _extract_map_events(
-        self,
-        bin_file: BIN,
-        common_event_sources: CommonEventSourceIndex | None = None,
-    ) -> tuple[dict | None, dict[str, Any] | None]:
-        """
-        从BIN文件中提取并根据公共事件集合进行去重
-
-        :param bin_file: BIN文件对象
-        :param common_event_sources: 公共事件来源索引，用于去重和记录来源
-        :returns: 地图事件数据字典，以及公共事件去重摘要
-        """
-        map_events = {}
-        dedup_by_category: dict[str, dict[str, set[str]]] = {}
-        if bin_file.theme_music:
-            map_events["theme_music"] = bin_file.theme_music
-
-        all_events_by_category = {}
-        for group in bin_file.data:
-            if group.music:
-                map_events["music"] = group.music.to_dict()
-            for event_data in group.bank_units:
-                if not event_data.events:
-                    continue
-
-                category = event_data.category
-                event_strings = [e.string for e in event_data.events]
-                unique_events_in_group = list(dict.fromkeys(event_strings))  # 保持顺序的去重
-
-                removed_events: list[str] = []
-                if common_event_sources:
-                    filtered_events: list[str] = []
-                    for event_name in unique_events_in_group:
-                        if event_name in common_event_sources:
-                            removed_events.append(event_name)
-                        else:
-                            filtered_events.append(event_name)
-                    unique_events_in_group = filtered_events
-
-                if removed_events:
-                    category_entry = dedup_by_category.setdefault(category, {"events": set(), "sources": set()})
-                    category_entry["events"].update(removed_events)
-                    for event_name in removed_events:
-                        category_entry["sources"].update(common_event_sources.get(event_name, set()))
-
-                if unique_events_in_group:
-                    if category not in all_events_by_category:
-                        all_events_by_category[category] = []
-                    all_events_by_category[category].extend(unique_events_in_group)
-
-        dedup_summary = None
-        if dedup_by_category:
-            categories = {}
-            total_removed = 0
-            for category, payload in dedup_by_category.items():
-                removed_event_names = sorted(payload["events"])
-                total_removed += len(removed_event_names)
-                categories[category] = {
-                    "count": len(removed_event_names),
-                    "examples": removed_event_names[:5],
-                    "sources": sorted(payload["sources"]),
-                }
-            dedup_summary = {
-                "total_removed": total_removed,
-                "remaining_event_count": sum(len(events) for events in all_events_by_category.values()),
-                "categories": categories,
-            }
-
-        if all_events_by_category:
-            map_events["events"] = all_events_by_category
-
-        return map_events if map_events else None, dedup_summary
-
-    def _deduplicate_single_map_banks(self, map_data: dict, common_banks_set: set) -> None:
-        """
-        对单个地图的Banks进行去重处理，移除与公共地图(ID 0)重复的bank path
-
-        :param map_data: 单个地图的完整数据（包含metadata和banks）
-        :param common_banks_set: 公共地图的bank path集合（元组形式）
-        """
-        if "banks" not in map_data:
-            return
-
-        bank_paths = map_data["banks"]
-        map_id = map_data.get("mapId", "unknown")
-
-        # 记录去重前的统计信息
-        original_categories = len(bank_paths)
-        original_paths_count = sum(len(paths_list) for paths_list in bank_paths.values())
-
-        # 遍历每个category，移除与公共数据重复的bank path
-        categories_to_remove = []
-        for category, paths_list in bank_paths.items():
-            # 筛选出当前地图独有的、非公共的bank path
-            unique_to_map = [path for path in paths_list if tuple(sorted(path)) not in common_banks_set]
-
-            if unique_to_map:
-                bank_paths[category] = unique_to_map
-            else:
-                # 如果该category下所有数据都是公共的，标记为待移除
-                categories_to_remove.append(category)
-
-        # 移除完全重复的categories
-        for category in categories_to_remove:
-            del bank_paths[category]
-
-        # 记录去重后的统计信息
-        remaining_categories = len(bank_paths)
-        remaining_paths_count = sum(len(paths_list) for paths_list in bank_paths.values())
-
-        logger.trace(
-            f"地图 {map_id} Banks去重完成: "
-            f"分类 {original_categories}→{remaining_categories}, "
-            f"路径 {original_paths_count}→{remaining_paths_count}"
-        )
-
-    def _optimize_champion_mappings(self, champion_data: dict) -> None:
-        """
-        优化单个英雄的映射关系，将部分共享升级为完全共享
-
-        :param champion_data: 英雄数据字典
-        """
-        for skin_id, mappings in champion_data["skinAudioMappings"].copy().items():
-            if not isinstance(mappings, dict):
-                continue
-
-            owner_ids = set(mappings.values())
-            if len(owner_ids) == 1:
-                owner_id = owner_ids.pop()
-                if skin_id not in champion_data["skins"]:
-                    champion_data["skinAudioMappings"][skin_id] = owner_id
-
-    def _process_map_events_for_id(
-        self, map_id: str, map_data: dict, common_event_sources: CommonEventSourceIndex | None = None
-    ) -> dict | None:
-        """
-        提取、去重并保存单个地图的事件数据（兼容性方法）
-
-        :param map_id: 地图ID
-        :param map_data: 地图数据字典
-        :param common_event_sources: 公共事件来源索引，用于去重
-        :returns: 地图事件数据字典，失败时返回None
-        """
-        # 如果未启用事件处理，直接返回None
-        if not self.process_events:
-            return None
-
-        if not map_data.get("binPath"):
-            return None
-
-        bin_file = self._load_map_bin_file(map_id, map_data)
-        if bin_file is None:
-            return None
-
-        return self._extract_map_events(bin_file, common_event_sources)[0]
-
-    def _record_map_event_dedup_summary(self, map_id: str, map_data: dict, dedup_summary: dict[str, Any]) -> None:
-        """记录地图公共事件去重造成的可解释差异。"""
-        total_removed = int(dedup_summary.get("total_removed", 0))
-        if total_removed <= 0:
-            return
-
-        map_name = self._get_map_name(map_data)
-        remaining_event_count = int(dedup_summary.get("remaining_event_count", 0))
-        source_labels = sorted(
-            {
-                source.split("/", 1)[0]
-                for payload in dedup_summary.get("categories", {}).values()
-                for source in payload.get("sources", [])
-            }
-        )
-        source_text = "、".join(source_labels) if source_labels else "公共地图"
-
-        if remaining_event_count == 0:
-            message = (
-                f"地图 {map_id} ({map_name}) 的事件在与 {source_text} 的公共事件去重后为空，"
-                f"共省略 {total_removed} 个事件；单独处理该地图时结果可能不同。"
-            )
-        else:
-            message = (
-                f"地图 {map_id} ({map_name}) 有 {total_removed} 个事件因与 {source_text} 的公共事件去重被省略，"
-                f"当前仍保留 {remaining_event_count} 个事件。"
-            )
-
-        detail_lines = []
-        for category, payload in sorted(dedup_summary.get("categories", {}).items()):
-            examples = ", ".join(payload.get("examples", [])) or "-"
-            sources = ", ".join(payload.get("sources", [])) or "-"
-            detail_lines.append(
-                f"category={category}, removed={payload.get('count', 0)}, sources=[{sources}], examples=[{examples}]"
-            )
-
-        detail = "\n".join(detail_lines)
-        record_runtime_note(self.ctx.runtime_cache, "update", message, label="数据更新", detail=detail)
-        for line in detail_lines:
-            logger.trace(f"地图 {map_id} 公共事件去重明细: {line}")
-
-    def _process_map_banks_for_id(self, map_id: str, map_data: dict) -> dict | None:
-        """
-        提取单个地图的Banks数据（用于预处理公共地图数据）
-
-        :param map_id: 地图ID
-        :param map_data: 地图数据字典
-        :returns: 地图Banks数据字典，失败时返回None
-        """
-        if not map_data.get("binPath"):
-            return None
-
-        bin_file = self._load_map_bin_file(map_id, map_data)
-        if bin_file is None:
-            return None
-
-        # 处理Banks数据
-        map_banks = {}
-        for group in bin_file.data:
-            for event_data in group.bank_units:
-                if event_data.bank_path:
-                    category = event_data.category
-                    if category not in map_banks:
-                        map_banks[category] = []
-                    map_banks[category].append(event_data.bank_path)
-
-        # 去重处理
-        for category, paths in map_banks.items():
-            unique_paths_tuples = dict.fromkeys(tuple(sorted(p)) for p in paths)
-            map_banks[category] = [list(p) for p in unique_paths_tuples]
-
-        if map_banks:
-            return {"banks": map_banks}
-        return None
-
-    def _create_base_data(self, entity_id: str, entity_type: str, **extra_fields) -> dict:
-        """
-        创建包含元数据和实体特定信息的基础数据结构。
-
-        :param entity_id: 实体ID（英雄ID或地图ID）
-        :param entity_type: 实体类型（'champion' 或 'map'）
-        :param extra_fields: 任何要添加到顶层的额外字段
-        :return: 包含元数据和附加字段的基础字典
-        """
-        # 使用通用函数创建包含所有标准元数据的对象
-        base_data = build_metadata_payload(self.version, self.languages)
-
-        # 检查是否为事件文件（通过是否存在'skins'或'map'顶级键来判断）
-        is_event_file = "skins" in extra_fields or "map" in extra_fields
-
-        # 如果是事件文件，则从中移除 'languages' 字段
-        if is_event_file and "metadata" in base_data and "languages" in base_data["metadata"]:
-            del base_data["metadata"]["languages"]
-
-        # 添加实体特定ID
-        if entity_type == "champion":
-            base_data["championId"] = entity_id
-        elif entity_type == "map":
-            base_data["mapId"] = entity_id
-
-        # 合并任何其他的附加字段
-        base_data.update(extra_fields)
-        return base_data
-
-    def _get_map_name(self, map_data: dict) -> str:
-        """
-        获取地图名称，优先使用当前语言，回退到默认语言
-
-        :param map_data: 地图数据
-        :returns: 地图名称
-        """
-        names = map_data.get("names", {})
-        if not names:
-            return map_data.get("mapStringId", "")
-
-        # 如果有多语言支持，尝试获取当前语言的名称
-        for lang in self.languages:
-            if lang in names:
-                return names[lang]
-
-        # 回退到默认语言
-        return names.get("default", map_data.get("mapStringId", ""))

--- a/src/lol_audio_unpack/manager/champion_bin_processor.py
+++ b/src/lol_audio_unpack/manager/champion_bin_processor.py
@@ -1,0 +1,274 @@
+"""英雄 BIN 链路处理。
+
+负责按英雄ID处理皮肤 BIN，提取 banks/events 数据并生成独立文件。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from league_tools.formats import BIN
+from loguru import logger
+
+from lol_audio_unpack.manager.bin_source import BinSource
+from lol_audio_unpack.manager.files import needs_update, write_data
+from lol_audio_unpack.utils.logging import performance_monitor
+
+if TYPE_CHECKING:
+    from lol_audio_unpack.app.types import AppContext
+
+# 类型别名定义
+ChampionData = dict[str, Any]
+
+
+class ChampionBinProcessor:
+    """处理英雄皮肤 BIN，生成 banks/events 数据。"""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        bin_source: BinSource,
+        *,
+        ctx: AppContext,
+        version: str,
+        force_update: bool,
+        process_events: bool,
+        game_path: Path,
+        champion_banks_dir: Path,
+        champion_events_dir: Path,
+    ):
+        """初始化英雄 BIN 处理器。
+
+        :param bin_source: BIN 来源辅助实例。
+        :param ctx: 运行时上下文。
+        :param version: 当前游戏版本。
+        :param force_update: 是否强制更新，忽略版本检查。
+        :param process_events: 是否处理事件数据。
+        :param game_path: 游戏客户端根目录。
+        :param champion_banks_dir: 英雄 banks 输出目录。
+        :param champion_events_dir: 英雄 events 输出目录。
+        """
+        self.bin_source = bin_source
+        self.ctx = ctx
+        self.version = version
+        self.force_update = force_update
+        self.process_events = process_events
+        self.game_path = game_path
+        self.champion_banks_dir = champion_banks_dir
+        self.champion_events_dir = champion_events_dir
+
+    def _is_dev_mode(self) -> bool:
+        """返回当前运行是否为开发模式。"""
+        return bool(self.ctx.config.dev_mode)
+
+    def _log_simple_progress(self, stage_name: str, index: int, total: int, entity_id: str) -> None:
+        """输出简单的批量处理进度日志。"""
+        logger.info(f"{stage_name}进度 {index}/{total}: {entity_id}")
+
+    @performance_monitor(level="DEBUG")
+    def _update_champions(self, data: dict) -> None:
+        """
+        处理英雄数据，按英雄ID分别生成文件
+
+        :param data: 包含英雄数据的字典
+        """
+        logger.info("开始处理英雄音频数据...")
+        self.champion_banks_dir.mkdir(parents=True, exist_ok=True)
+        self.champion_events_dir.mkdir(parents=True, exist_ok=True)
+
+        champions = data.get("champions", {})
+        sorted_champion_ids = sorted(champions.keys(), key=int)
+
+        total_champions = len(sorted_champion_ids)
+        for index, champion_id in enumerate(sorted_champion_ids, start=1):
+            champion_data = champions[champion_id]
+            self._log_simple_progress("处理英雄", index, total_champions, champion_id)
+            self._process_champion_skins(champion_data, champion_id)
+
+        logger.success(f"英雄Banks数据更新完成，共处理 {total_champions} 个英雄")
+
+    @performance_monitor(level="DEBUG")
+    def _process_champion_skins(self, champion_data: ChampionData, champion_id: str) -> None:
+        """
+        处理单个英雄的所有皮肤，提取音频数据并生成独立文件
+
+        :param champion_data: 英雄数据字典
+        :param champion_id: 英雄ID
+        """
+        alias_raw = champion_data.get("alias", "")
+        alias = alias_raw.lower()
+        if not alias:
+            return
+
+        # 检查是否需要更新
+        banks_file_base = self.champion_banks_dir / champion_id
+        events_file_base = self.champion_events_dir / champion_id
+
+        if not needs_update(
+            banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()
+        ) and not needs_update(events_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
+            logger.trace(f"英雄 {champion_id} ({alias}) 的数据已是最新，跳过处理")
+            return
+
+        path_to_skin_id_map: dict[str, str] = {}
+        skins_data = champion_data.get("skins", [])
+        sorted_skins_data = sorted(skins_data, key=lambda s: int(s["id"]))
+
+        base_skin_id = None
+        for skin in sorted_skins_data:
+            skin_id_str = str(skin["id"])
+            if skin.get("isBase"):
+                base_skin_id = skin_id_str
+
+            if bin_path := skin.get("binPath"):
+                path_to_skin_id_map[bin_path] = skin_id_str
+            for chroma in skin.get("chromas", []):
+                chroma_id_str = str(chroma["id"])
+                if bin_path := chroma.get("binPath"):
+                    path_to_skin_id_map[bin_path] = chroma_id_str
+
+        if not path_to_skin_id_map:
+            return
+
+        bin_paths = list(path_to_skin_id_map.keys())
+        root_wad_path = champion_data.get("wad", {}).get("root")
+        full_wad_path = self.game_path / root_wad_path if root_wad_path else None
+        local_required_dir = Path("data") / "characters" / alias_raw
+        try:
+            logger.trace(f"从 {alias} 提取 {len(bin_paths)} 个BIN文件")
+            bin_raws = self.bin_source._extract_bin_raws(
+                wad_path=full_wad_path,
+                bin_paths=bin_paths,
+                entity_label=f"英雄 {champion_id} ({alias})",
+                local_required_dir=local_required_dir,
+            )
+            if not bin_raws or not bin_raws[0]:
+                logger.warning(f"英雄 {champion_id} ({alias}) 的首个BIN缺失或为空，跳过处理")
+                return
+            raw_data_map = dict(zip(bin_paths, bin_raws, strict=False))
+        except (FileNotFoundError, ValueError):
+            logger.opt(exception=True).error(f"处理英雄 {alias} 的本地BIN时出错")
+            return
+        except Exception:
+            logger.opt(exception=True).error(f"处理英雄 {alias} 的WAD文件时出错")
+            return
+
+        skin_ids_sorted = sorted(path_to_skin_id_map.values(), key=int)
+        path_to_id_reversed = {v: k for k, v in path_to_skin_id_map.items()}
+
+        # 初始化英雄的banks和events数据
+        champion_banks_data = self.bin_source._create_base_data(
+            champion_id, "champion", alias=alias, skinAudioMappings={}, skins={}
+        )
+
+        champion_skin_events = {}
+        bank_path_to_owner_map: dict[tuple, str] = {}
+
+        for skin_id in skin_ids_sorted:
+            path = path_to_id_reversed[skin_id]
+            if not (bin_raw := raw_data_map.get(path)):
+                continue
+
+            try:
+                bin_file = BIN(bin_raw)
+                is_new_skin_entry = True
+
+                for group in bin_file.data:
+                    for event_data in group.bank_units:
+                        if event_data.bank_path:
+                            bank_path_fingerprint = tuple(sorted(event_data.bank_path))
+                            category = event_data.category
+
+                            if owner_id := bank_path_to_owner_map.get(bank_path_fingerprint):
+                                if skin_id != owner_id and "_Base_" not in category:
+                                    if skin_id not in champion_banks_data["skinAudioMappings"]:
+                                        champion_banks_data["skinAudioMappings"][skin_id] = {}
+                                    champion_banks_data["skinAudioMappings"][skin_id][category] = owner_id
+                            else:
+                                bank_path_to_owner_map[bank_path_fingerprint] = skin_id
+                                if skin_id not in champion_banks_data["skins"]:
+                                    champion_banks_data["skins"][skin_id] = {}
+                                if category not in champion_banks_data["skins"][skin_id]:
+                                    champion_banks_data["skins"][skin_id][category] = []
+                                champion_banks_data["skins"][skin_id][category].append(event_data.bank_path)
+
+                                if is_new_skin_entry and self.process_events:
+                                    if skin_events := self._extract_skin_events(bin_file, base_skin_id, skin_id):
+                                        champion_skin_events[skin_id] = skin_events
+                                    is_new_skin_entry = False
+
+            except Exception:
+                logger.opt(exception=True).error(f"解析皮肤BIN失败: {path}")
+                if self._is_dev_mode():
+                    raise
+
+        # 优化映射关系
+        self._optimize_champion_mappings(champion_banks_data)
+
+        # 写入banks数据
+        if needs_update(banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
+            write_data(champion_banks_data, banks_file_base, dev_mode=self._is_dev_mode())
+
+        # 写入events数据
+        if champion_skin_events and needs_update(
+            events_file_base,
+            self.version,
+            self.force_update,
+            dev_mode=self._is_dev_mode(),
+        ):
+            final_event_data = self.bin_source._create_base_data(
+                champion_id, "champion", alias=alias, skins=champion_skin_events
+            )
+            write_data(final_event_data, events_file_base, dev_mode=self._is_dev_mode())
+
+    def _extract_skin_events(self, bin_file: BIN, base_skin_id: str | None, current_skin_id: str) -> dict | None:
+        """
+        提取一个皮肤BIN文件中的所有事件数据
+
+        :param bin_file: BIN文件对象
+        :param base_skin_id: 基础皮肤ID，用于过滤基础皮肤事件
+        :param current_skin_id: 当前皮肤ID
+        :returns: 皮肤事件数据字典，无数据时返回None
+        """
+        skin_events = {}
+        if bin_file.theme_music:
+            skin_events["theme_music"] = bin_file.theme_music
+
+        all_events_by_category = {}
+        for group in bin_file.data:
+            if group.music:
+                skin_events["music"] = group.music.to_dict()
+            for event_data in group.bank_units:
+                if base_skin_id and current_skin_id != base_skin_id and "_Base_" in event_data.category:
+                    continue
+                if event_data.events:
+                    category = event_data.category
+                    if category not in all_events_by_category:
+                        all_events_by_category[category] = []
+                    event_strings = [e.string for e in event_data.events]
+                    # 添加到category，稍后统一去重
+                    all_events_by_category[category].extend(event_strings)
+
+        if all_events_by_category:
+            # 对每个category的事件列表进行去重
+            for category, events_list in all_events_by_category.items():
+                all_events_by_category[category] = list(dict.fromkeys(events_list))  # 保持顺序的去重
+            skin_events["events"] = all_events_by_category
+
+        return skin_events if skin_events else None
+
+    def _optimize_champion_mappings(self, champion_data: dict) -> None:
+        """
+        优化单个英雄的映射关系，将部分共享升级为完全共享
+
+        :param champion_data: 英雄数据字典
+        """
+        for skin_id, mappings in champion_data["skinAudioMappings"].copy().items():
+            if not isinstance(mappings, dict):
+                continue
+
+            owner_ids = set(mappings.values())
+            if len(owner_ids) == 1:
+                owner_id = owner_ids.pop()
+                if skin_id not in champion_data["skins"]:
+                    champion_data["skinAudioMappings"][skin_id] = owner_id

--- a/src/lol_audio_unpack/manager/map_bin_processor.py
+++ b/src/lol_audio_unpack/manager/map_bin_processor.py
@@ -1,0 +1,427 @@
+"""地图 BIN 链路处理。
+
+负责按地图ID处理 BIN，提取 banks/events 数据，
+并对非公共地图应用公共地图(ID 0)的去重逻辑。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from lol_audio_unpack.manager.bin_source import BinSource
+from lol_audio_unpack.manager.files import needs_update, write_data
+from lol_audio_unpack.utils.logging import performance_monitor
+from lol_audio_unpack.utils.run_summary import record_runtime_note
+
+if TYPE_CHECKING:
+    from lol_audio_unpack.app.types import AppContext
+
+# 类型别名定义
+CommonEventSourceIndex = dict[str, set[str]]
+
+
+class MapBinProcessor:
+    """处理地图 BIN，生成 banks/events 数据并执行公共数据去重。"""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        bin_source: BinSource,
+        *,
+        ctx: AppContext,
+        version: str,
+        force_update: bool,
+        process_events: bool,
+        map_banks_dir: Path,
+        map_events_dir: Path,
+        languages: list[str] | None = None,
+    ):
+        """初始化地图 BIN 处理器。
+
+        :param bin_source: BIN 来源辅助实例。
+        :param ctx: 运行时上下文。
+        :param version: 当前游戏版本。
+        :param force_update: 是否强制更新，忽略版本检查。
+        :param process_events: 是否处理事件数据。
+        :param map_banks_dir: 地图 banks 输出目录。
+        :param map_events_dir: 地图 events 输出目录。
+        :param languages: 元数据语言列表，在 update() 中初始化。
+        """
+        self.bin_source = bin_source
+        self.ctx = ctx
+        self.version = version
+        self.force_update = force_update
+        self.process_events = process_events
+        self.map_banks_dir = map_banks_dir
+        self.map_events_dir = map_events_dir
+        self.languages: list[str] = languages if languages is not None else []
+
+    def _is_dev_mode(self) -> bool:
+        """返回当前运行是否为开发模式。"""
+        return bool(self.ctx.config.dev_mode)
+
+    def _log_simple_progress(self, stage_name: str, index: int, total: int, entity_id: str) -> None:
+        """输出简单的批量处理进度日志。"""
+        logger.info(f"{stage_name}进度 {index}/{total}: {entity_id}")
+
+    @performance_monitor(level="DEBUG")
+    def _update_maps(self, data: dict) -> None:
+        """
+        处理地图数据，按地图ID分别生成文件
+
+        :param data: 包含地图数据的字典
+        """
+        logger.info("开始处理地图音频数据...")
+        self.map_banks_dir.mkdir(parents=True, exist_ok=True)
+        self.map_events_dir.mkdir(parents=True, exist_ok=True)
+
+        maps = data.get("maps", {})
+
+        # 预处理公共地图(ID 0)的事件数据和Banks数据
+        common_event_sources: CommonEventSourceIndex = {}
+        common_banks_set = set()
+        if "0" in maps:
+            logger.debug("正在预处理公共地图(ID 0)的数据...")
+            try:
+                # 预处理事件数据
+                if map_events := self._process_map_events_for_id("0", maps["0"]):
+                    if "events" in map_events:
+                        for category, events_list in map_events["events"].items():
+                            for event_string in events_list:
+                                common_event_sources.setdefault(event_string, set()).add(f"地图 0/{category}")
+
+                # 预处理Banks数据
+                if map_banks := self._process_map_banks_for_id("0", maps["0"]):
+                    if "banks" in map_banks:
+                        for paths_list in map_banks["banks"].values():
+                            for path in paths_list:
+                                common_banks_set.add(tuple(sorted(path)))
+            except Exception:
+                logger.opt(exception=True).error("预处理公共地图(ID 0)的数据时出错")
+                if self._is_dev_mode():
+                    raise
+
+        map_items = list(maps.items())
+        total_maps = len(map_items)
+        for index, (map_id, map_data) in enumerate(map_items, start=1):
+            self._log_simple_progress("处理地图", index, total_maps, map_id)
+            self._process_single_map(map_id, map_data, common_event_sources, common_banks_set)
+
+        logger.success(f"地图Banks数据更新完成，共处理 {total_maps} 个地图")
+
+    def _process_single_map(
+        self,
+        map_id: str,
+        map_data: dict,
+        common_event_sources: CommonEventSourceIndex | None = None,
+        common_banks_set: set | None = None,
+    ) -> None:
+        """
+        处理单个地图的Banks和Events数据
+
+        :param map_id: 地图ID
+        :param map_data: 地图数据字典
+        :param common_event_sources: 公共事件来源索引，用于事件去重和总结
+        :param common_banks_set: 公共Banks集合，用于去重
+        """
+        banks_file_base = self.map_banks_dir / map_id
+        events_file_base = self.map_events_dir / map_id
+
+        if not needs_update(
+            banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()
+        ) and not needs_update(events_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
+            logger.trace(f"地图 {map_id} 的数据已是最新，跳过处理")
+            return
+
+        if not map_data.get("binPath"):
+            return
+
+        bin_file = self.bin_source._load_map_bin_file(map_id, map_data)
+        if bin_file is None:
+            return
+
+        # 处理Banks数据
+        map_banks = {}
+        for group in bin_file.data:
+            for event_data in group.bank_units:
+                if event_data.bank_path:
+                    category = event_data.category
+                    if category not in map_banks:
+                        map_banks[category] = []
+                    map_banks[category].append(event_data.bank_path)
+
+        # 去重处理
+        for category, paths in map_banks.items():
+            unique_paths_tuples = dict.fromkeys(tuple(sorted(p)) for p in paths)
+            map_banks[category] = [list(p) for p in unique_paths_tuples]
+
+        # 写入Banks数据
+        if map_banks and needs_update(banks_file_base, self.version, self.force_update, dev_mode=self._is_dev_mode()):
+            map_banks_data = self.bin_source._create_base_data(
+                map_id, "map", name=self._get_map_name(map_data), banks=map_banks
+            )
+
+            # 对非公共地图进行去重处理
+            if map_id != "0" and common_banks_set:
+                self._deduplicate_single_map_banks(map_banks_data, common_banks_set)
+
+            # 去重后检查是否还有数据需要写入
+            if map_banks_data.get("banks"):
+                write_data(map_banks_data, banks_file_base, dev_mode=self._is_dev_mode())
+            else:
+                logger.trace(f"地图 {map_id} 去重后无独有Banks数据，跳过写入")
+
+        # 处理Events数据，只有在启用事件处理时才提取
+        if self.process_events and needs_update(
+            events_file_base,
+            self.version,
+            self.force_update,
+            dev_mode=self._is_dev_mode(),
+        ):
+            map_events, dedup_summary = self._extract_map_events(
+                bin_file,
+                common_event_sources if map_id != "0" else None,
+            )
+            if dedup_summary:
+                self._record_map_event_dedup_summary(map_id, map_data, dedup_summary)
+            if map_events:
+                final_event_data = self.bin_source._create_base_data(
+                    map_id, "map", name=self._get_map_name(map_data), map=map_events
+                )
+                write_data(final_event_data, events_file_base, dev_mode=self._is_dev_mode())
+
+    def _extract_map_events(
+        self,
+        bin_file,
+        common_event_sources: CommonEventSourceIndex | None = None,
+    ) -> tuple[dict | None, dict[str, Any] | None]:
+        """
+        从BIN文件中提取并根据公共事件集合进行去重
+
+        :param bin_file: BIN文件对象
+        :param common_event_sources: 公共事件来源索引，用于去重和记录来源
+        :returns: 地图事件数据字典，以及公共事件去重摘要
+        """
+        map_events = {}
+        dedup_by_category: dict[str, dict[str, set[str]]] = {}
+        if bin_file.theme_music:
+            map_events["theme_music"] = bin_file.theme_music
+
+        all_events_by_category = {}
+        for group in bin_file.data:
+            if group.music:
+                map_events["music"] = group.music.to_dict()
+            for event_data in group.bank_units:
+                if not event_data.events:
+                    continue
+
+                category = event_data.category
+                event_strings = [e.string for e in event_data.events]
+                unique_events_in_group = list(dict.fromkeys(event_strings))  # 保持顺序的去重
+
+                removed_events: list[str] = []
+                if common_event_sources:
+                    filtered_events: list[str] = []
+                    for event_name in unique_events_in_group:
+                        if event_name in common_event_sources:
+                            removed_events.append(event_name)
+                        else:
+                            filtered_events.append(event_name)
+                    unique_events_in_group = filtered_events
+
+                if removed_events:
+                    category_entry = dedup_by_category.setdefault(category, {"events": set(), "sources": set()})
+                    category_entry["events"].update(removed_events)
+                    for event_name in removed_events:
+                        category_entry["sources"].update(common_event_sources.get(event_name, set()))
+
+                if unique_events_in_group:
+                    if category not in all_events_by_category:
+                        all_events_by_category[category] = []
+                    all_events_by_category[category].extend(unique_events_in_group)
+
+        dedup_summary = None
+        if dedup_by_category:
+            categories = {}
+            total_removed = 0
+            for category, payload in dedup_by_category.items():
+                removed_event_names = sorted(payload["events"])
+                total_removed += len(removed_event_names)
+                categories[category] = {
+                    "count": len(removed_event_names),
+                    "examples": removed_event_names[:5],
+                    "sources": sorted(payload["sources"]),
+                }
+            dedup_summary = {
+                "total_removed": total_removed,
+                "remaining_event_count": sum(len(events) for events in all_events_by_category.values()),
+                "categories": categories,
+            }
+
+        if all_events_by_category:
+            map_events["events"] = all_events_by_category
+
+        return map_events if map_events else None, dedup_summary
+
+    def _deduplicate_single_map_banks(self, map_data: dict, common_banks_set: set) -> None:
+        """
+        对单个地图的Banks进行去重处理，移除与公共地图(ID 0)重复的bank path
+
+        :param map_data: 单个地图的完整数据（包含metadata和banks）
+        :param common_banks_set: 公共地图的bank path集合（元组形式）
+        """
+        if "banks" not in map_data:
+            return
+
+        bank_paths = map_data["banks"]
+        map_id = map_data.get("mapId", "unknown")
+
+        # 记录去重前的统计信息
+        original_categories = len(bank_paths)
+        original_paths_count = sum(len(paths_list) for paths_list in bank_paths.values())
+
+        # 遍历每个category，移除与公共数据重复的bank path
+        categories_to_remove = []
+        for category, paths_list in bank_paths.items():
+            # 筛选出当前地图独有的、非公共的bank path
+            unique_to_map = [path for path in paths_list if tuple(sorted(path)) not in common_banks_set]
+
+            if unique_to_map:
+                bank_paths[category] = unique_to_map
+            else:
+                # 如果该category下所有数据都是公共的，标记为待移除
+                categories_to_remove.append(category)
+
+        # 移除完全重复的categories
+        for category in categories_to_remove:
+            del bank_paths[category]
+
+        # 记录去重后的统计信息
+        remaining_categories = len(bank_paths)
+        remaining_paths_count = sum(len(paths_list) for paths_list in bank_paths.values())
+
+        logger.trace(
+            f"地图 {map_id} Banks去重完成: "
+            f"分类 {original_categories}→{remaining_categories}, "
+            f"路径 {original_paths_count}→{remaining_paths_count}"
+        )
+
+    def _process_map_events_for_id(
+        self, map_id: str, map_data: dict, common_event_sources: CommonEventSourceIndex | None = None
+    ) -> dict | None:
+        """
+        提取、去重并保存单个地图的事件数据（兼容性方法）
+
+        :param map_id: 地图ID
+        :param map_data: 地图数据字典
+        :param common_event_sources: 公共事件来源索引，用于去重
+        :returns: 地图事件数据字典，失败时返回None
+        """
+        # 如果未启用事件处理，直接返回None
+        if not self.process_events:
+            return None
+
+        if not map_data.get("binPath"):
+            return None
+
+        bin_file = self.bin_source._load_map_bin_file(map_id, map_data)
+        if bin_file is None:
+            return None
+
+        return self._extract_map_events(bin_file, common_event_sources)[0]
+
+    def _record_map_event_dedup_summary(self, map_id: str, map_data: dict, dedup_summary: dict[str, Any]) -> None:
+        """记录地图公共事件去重造成的可解释差异。"""
+        total_removed = int(dedup_summary.get("total_removed", 0))
+        if total_removed <= 0:
+            return
+
+        map_name = self._get_map_name(map_data)
+        remaining_event_count = int(dedup_summary.get("remaining_event_count", 0))
+        source_labels = sorted(
+            {
+                source.split("/", 1)[0]
+                for payload in dedup_summary.get("categories", {}).values()
+                for source in payload.get("sources", [])
+            }
+        )
+        source_text = "、".join(source_labels) if source_labels else "公共地图"
+
+        if remaining_event_count == 0:
+            message = (
+                f"地图 {map_id} ({map_name}) 的事件在与 {source_text} 的公共事件去重后为空，"
+                f"共省略 {total_removed} 个事件；单独处理该地图时结果可能不同。"
+            )
+        else:
+            message = (
+                f"地图 {map_id} ({map_name}) 有 {total_removed} 个事件因与 {source_text} 的公共事件去重被省略，"
+                f"当前仍保留 {remaining_event_count} 个事件。"
+            )
+
+        detail_lines = []
+        for category, payload in sorted(dedup_summary.get("categories", {}).items()):
+            examples = ", ".join(payload.get("examples", [])) or "-"
+            sources = ", ".join(payload.get("sources", [])) or "-"
+            detail_lines.append(
+                f"category={category}, removed={payload.get('count', 0)}, sources=[{sources}], examples=[{examples}]"
+            )
+
+        detail = "\n".join(detail_lines)
+        record_runtime_note(self.ctx.runtime_cache, "update", message, label="数据更新", detail=detail)
+        for line in detail_lines:
+            logger.trace(f"地图 {map_id} 公共事件去重明细: {line}")
+
+    def _process_map_banks_for_id(self, map_id: str, map_data: dict) -> dict | None:
+        """
+        提取单个地图的Banks数据（用于预处理公共地图数据）
+
+        :param map_id: 地图ID
+        :param map_data: 地图数据字典
+        :returns: 地图Banks数据字典，失败时返回None
+        """
+        if not map_data.get("binPath"):
+            return None
+
+        bin_file = self.bin_source._load_map_bin_file(map_id, map_data)
+        if bin_file is None:
+            return None
+
+        # 处理Banks数据
+        map_banks = {}
+        for group in bin_file.data:
+            for event_data in group.bank_units:
+                if event_data.bank_path:
+                    category = event_data.category
+                    if category not in map_banks:
+                        map_banks[category] = []
+                    map_banks[category].append(event_data.bank_path)
+
+        # 去重处理
+        for category, paths in map_banks.items():
+            unique_paths_tuples = dict.fromkeys(tuple(sorted(p)) for p in paths)
+            map_banks[category] = [list(p) for p in unique_paths_tuples]
+
+        if map_banks:
+            return {"banks": map_banks}
+        return None
+
+    def _get_map_name(self, map_data: dict) -> str:
+        """
+        获取地图名称，优先使用当前语言，回退到默认语言
+
+        :param map_data: 地图数据
+        :returns: 地图名称
+        """
+        names = map_data.get("names", {})
+        if not names:
+            return map_data.get("mapStringId", "")
+
+        # 如果有多语言支持，尝试获取当前语言的名称
+        for lang in self.languages:
+            if lang in names:
+                return names[lang]
+
+        # 回退到默认语言
+        return names.get("default", map_data.get("mapStringId", ""))

--- a/tests/cli/test_cli_remote_smoke.py
+++ b/tests/cli/test_cli_remote_smoke.py
@@ -1,0 +1,103 @@
+"""远端 CLI 烟测。"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lol_audio_unpack.manager.utils import find_data_file
+
+pytestmark = [pytest.mark.integration, pytest.mark.remote_live]
+
+LIVE_REGION = os.environ.get("LOL_REMOTE_SMOKE_REGION", "EUW")
+GAME_REGION = os.environ.get("LOL_REMOTE_SMOKE_GAME_REGION", "zh_CN")
+CHAMPION_ID = os.environ.get("LOL_REMOTE_SMOKE_CHAMPION_ID", "1")
+TIMEOUT_SECONDS = int(os.environ.get("LOL_REMOTE_SMOKE_TIMEOUT", "900"))
+
+
+def _run_cli(output_path: Path) -> subprocess.CompletedProcess[str]:
+    """运行最小远端 CLI 链路。
+
+    Args:
+        output_path: 本次烟测的独立输出根目录。
+
+    Returns:
+        CLI 子进程结果。
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "lol_audio_unpack",
+            "update",
+            "extract",
+            "--champions",
+            CHAMPION_ID,
+            "--source-mode",
+            "remote_snapshot",
+            "--remote-live-region",
+            LIVE_REGION,
+            "--game-region",
+            GAME_REGION,
+            "--output-path",
+            str(output_path),
+            "--exclude-type",
+            "SFX,MUSIC",
+            "--skip-events",
+            "--max-workers",
+            "1",
+            "--log-level",
+            "INFO",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=TIMEOUT_SECONDS,
+    )
+
+
+def _version_root(output_path: Path) -> Path:
+    """返回远端 smoke 生成的版本目录。
+
+    Args:
+        output_path: CLI 输出根目录。
+
+    Returns:
+        manifest 下唯一的版本目录。
+    """
+    manifest_root = output_path / "manifest"
+    version_roots = sorted(path for path in manifest_root.iterdir() if path.is_dir())
+    assert len(version_roots) == 1, f"应只生成一个版本目录: {version_roots}"
+    return version_roots[0]
+
+
+def test_remote_snapshot_cli_smoke_extracts_champion_vo(tmp_path: Path) -> None:
+    """CLI 应能从远端 live 快照解包一个英雄 VO。"""
+    output_path = tmp_path / "remote_cli_smoke"
+
+    result = _run_cli(output_path)
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+
+    version_root = _version_root(output_path)
+    data_file = find_data_file(version_root / "data", dev_mode=False)
+    assert data_file is not None
+
+    champion_root = output_path / "audios" / version_root.name / "champions"
+    champion_dirs = [
+        path
+        for path in champion_root.iterdir()
+        if path.is_dir() and path.name.startswith(f"{CHAMPION_ID}·")
+    ]
+    assert champion_dirs, f"未找到英雄 {CHAMPION_ID} 的输出目录"
+
+    wem_files = list(champion_dirs[0].rglob("*.wem"))
+    assert wem_files, f"英雄 {CHAMPION_ID} 未解包出任何 wem 文件"
+
+    report_file = output_path / "reports" / version_root.name / "champions" / f"_{CHAMPION_ID}_metadata.yaml"
+    assert report_file.is_file()

--- a/tests/manager/test_manager_bin_updater.py
+++ b/tests/manager/test_manager_bin_updater.py
@@ -3,33 +3,37 @@ from types import SimpleNamespace
 
 import pytest
 
+from lol_audio_unpack.manager import bin_source as m_bin_source
 from lol_audio_unpack.manager import bin_updater as m_bin_updater
+from lol_audio_unpack.manager import champion_bin_processor as m_champion_processor
+from lol_audio_unpack.manager import map_bin_processor as m_map_processor
 from lol_audio_unpack.utils.run_summary import get_or_create_run_summary
 
 pytestmark = pytest.mark.unit
 
 
-def _build_updater(tmp_path: Path) -> m_bin_updater.BinUpdater:
-    """构造用于单测的最小 `BinUpdater` 实例。
+def _build_bin_source(tmp_path: Path) -> m_bin_source.BinSource:
+    """构造用于单测的最小 `BinSource` 实例。
 
     Args:
         tmp_path: pytest 提供的临时目录。
 
     Returns:
-        仅初始化当前测试所需字段的 `BinUpdater` 对象。
+        仅初始化当前测试所需字段的 `BinSource` 对象。
     """
-    updater = m_bin_updater.BinUpdater.__new__(m_bin_updater.BinUpdater)
-    updater.ctx = SimpleNamespace(config=SimpleNamespace(game_path=tmp_path, dev_mode=False), paths=SimpleNamespace())
-    updater.use_local_bin_flag_file = tmp_path / ".use_local_bin"
-    updater.local_bin_input_dir = tmp_path / "bin_input"
-    updater.local_bin_input_dir.mkdir(parents=True, exist_ok=True)
-    return updater
+    source = m_bin_source.BinSource.__new__(m_bin_source.BinSource)
+    source.ctx = SimpleNamespace(config=SimpleNamespace(game_path=tmp_path, dev_mode=False), paths=SimpleNamespace())
+    source.game_path = tmp_path
+    source.use_local_bin_flag_file = tmp_path / ".use_local_bin"
+    source.local_bin_input_dir = tmp_path / "bin_input"
+    source.local_bin_input_dir.mkdir(parents=True, exist_ok=True)
+    return source
 
 
 def test_extract_bin_raws_prefers_wad_when_wad_exists(tmp_path, monkeypatch):
     """验证存在 WAD 文件时优先从 WAD 提取 BIN 原始数据。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
     calls = []
 
@@ -41,12 +45,12 @@ def test_extract_bin_raws_prefers_wad_when_wad_exists(tmp_path, monkeypatch):
             calls.append((self.path, list(bin_paths), raw))
             return [b"from-wad"]
 
-    monkeypatch.setattr(m_bin_updater, "WAD", FakeWAD)
+    monkeypatch.setattr(m_bin_source, "WAD", FakeWAD)
 
     wad_path = tmp_path / "Annie.wad.client"
     wad_path.write_bytes(b"")
 
-    result = updater._extract_bin_raws(
+    result = source._extract_bin_raws(
         wad_path=wad_path,
         bin_paths=["data/characters/Annie/skins/skin0001.bin"],
         entity_label="英雄 1 (annie)",
@@ -59,14 +63,14 @@ def test_extract_bin_raws_prefers_wad_when_wad_exists(tmp_path, monkeypatch):
 
 def test_extract_bin_raws_reads_local_files_when_flag_enabled(tmp_path):
     """验证启用本地 BIN 模式后会直接读取本地文件。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
-    target_file = updater.local_bin_input_dir / "data/characters/Annie/skins/skin0001.bin"
+    target_file = source.local_bin_input_dir / "data/characters/Annie/skins/skin0001.bin"
     target_file.parent.mkdir(parents=True, exist_ok=True)
     target_file.write_bytes(b"from-local")
 
-    result = updater._extract_bin_raws(
+    result = source._extract_bin_raws(
         wad_path=tmp_path / "missing.wad.client",
         bin_paths=["data/characters/Annie/skins/skin0001.bin"],
         entity_label="英雄 1 (annie)",
@@ -78,17 +82,17 @@ def test_extract_bin_raws_reads_local_files_when_flag_enabled(tmp_path):
 
 def test_extract_bin_raws_logs_fallback_to_local_bin_when_wad_missing(tmp_path, monkeypatch):
     """验证 WAD 缺失但启用本地 BIN 模式时会输出回退诊断日志。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
-    target_file = updater.local_bin_input_dir / "data/characters/Annie/skins/skin0001.bin"
+    target_file = source.local_bin_input_dir / "data/characters/Annie/skins/skin0001.bin"
     target_file.parent.mkdir(parents=True, exist_ok=True)
     target_file.write_bytes(b"from-local")
 
     debug_messages: list[str] = []
     trace_messages: list[str] = []
     monkeypatch.setattr(
-        m_bin_updater,
+        m_bin_source,
         "logger",
         SimpleNamespace(
             debug=lambda message: debug_messages.append(str(message)),
@@ -98,7 +102,7 @@ def test_extract_bin_raws_logs_fallback_to_local_bin_when_wad_missing(tmp_path, 
     )
 
     missing_wad = tmp_path / "missing.wad.client"
-    result = updater._extract_bin_raws(
+    result = source._extract_bin_raws(
         wad_path=missing_wad,
         bin_paths=["data/characters/Annie/skins/skin0001.bin"],
         entity_label="英雄 1 (annie)",
@@ -107,16 +111,16 @@ def test_extract_bin_raws_logs_fallback_to_local_bin_when_wad_missing(tmp_path, 
 
     assert result == [b"from-local"]
     assert debug_messages == [f"英雄 1 (annie) 的WAD文件不可用，回退到本地BIN模式: {missing_wad}"]
-    assert any(str(updater.local_bin_input_dir) in message for message in trace_messages)
+    assert any(str(source.local_bin_input_dir) in message for message in trace_messages)
 
 
 def test_extract_bin_raws_raises_when_flag_enabled_but_entity_dir_missing(tmp_path):
     """验证启用本地 BIN 模式但实体目录缺失时会抛出异常。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
     with pytest.raises(FileNotFoundError, match="本地BIN实体目录不存在"):
-        updater._extract_bin_raws(
+        source._extract_bin_raws(
             wad_path=tmp_path / "missing.wad.client",
             bin_paths=["data/characters/Annie/skins/skin0001.bin"],
             entity_label="英雄 1 (annie)",
@@ -126,9 +130,9 @@ def test_extract_bin_raws_raises_when_flag_enabled_but_entity_dir_missing(tmp_pa
 
 def test_extract_bin_raws_returns_empty_when_local_mode_disabled(tmp_path):
     """验证未启用本地 BIN 模式时缺失 WAD 会返回空结果。"""
-    updater = _build_updater(tmp_path)
+    source = _build_bin_source(tmp_path)
 
-    result = updater._extract_bin_raws(
+    result = source._extract_bin_raws(
         wad_path=tmp_path / "missing.wad.client",
         bin_paths=["data/characters/Annie/skins/skin0001.bin"],
         entity_label="英雄 1 (annie)",
@@ -140,12 +144,12 @@ def test_extract_bin_raws_returns_empty_when_local_mode_disabled(tmp_path):
 
 def test_extract_bin_raws_raises_when_local_bin_root_missing(tmp_path):
     """验证本地 BIN 根目录缺失时会抛出异常。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
-    updater.local_bin_input_dir.rmdir()
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source.local_bin_input_dir.rmdir()
 
     with pytest.raises(FileNotFoundError, match="目录不存在"):
-        updater._extract_bin_raws(
+        source._extract_bin_raws(
             wad_path=tmp_path / "missing.wad.client",
             bin_paths=["data/characters/Annie/skins/skin0001.bin"],
             entity_label="英雄 1 (annie)",
@@ -155,11 +159,11 @@ def test_extract_bin_raws_raises_when_local_bin_root_missing(tmp_path):
 
 def test_extract_bin_raws_raises_for_path_traversal(tmp_path):
     """验证越界路径会被拒绝处理。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
     with pytest.raises(ValueError, match="越界"):
-        updater._extract_bin_raws(
+        source._extract_bin_raws(
             wad_path=tmp_path / "missing.wad.client",
             bin_paths=["../../outside.bin"],
             entity_label="英雄 1 (annie)",
@@ -169,15 +173,15 @@ def test_extract_bin_raws_raises_for_path_traversal(tmp_path):
 
 def test_extract_bin_raws_allows_partial_missing_and_keeps_order(tmp_path):
     """验证部分 BIN 缺失时仍保持原始顺序返回结果。"""
-    updater = _build_updater(tmp_path)
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
-    base_dir = updater.local_bin_input_dir / "data/characters/Annie/skins"
+    base_dir = source.local_bin_input_dir / "data/characters/Annie/skins"
     base_dir.mkdir(parents=True, exist_ok=True)
     (base_dir / "skin0001.bin").write_bytes(b"first")
     (base_dir / "skin0003.bin").write_bytes(b"third")
 
-    result = updater._extract_bin_raws(
+    result = source._extract_bin_raws(
         wad_path=tmp_path / "missing.wad.client",
         bin_paths=[
             "data/characters/Annie/skins/skin0001.bin",
@@ -193,20 +197,20 @@ def test_extract_bin_raws_allows_partial_missing_and_keeps_order(tmp_path):
 
 def test_process_champion_skins_skips_when_first_bin_missing(tmp_path, monkeypatch):
     """验证首个皮肤 BIN 缺失时会跳过整组英雄皮肤处理。"""
-    updater = m_bin_updater.BinUpdater.__new__(m_bin_updater.BinUpdater)
-    updater.ctx = SimpleNamespace(config=SimpleNamespace(game_path=tmp_path, dev_mode=False), paths=SimpleNamespace())
-    updater.force_update = False
-    updater.process_events = False
-    updater.version = "16.3"
-    updater.game_path = tmp_path
-    updater.champion_banks_dir = tmp_path / "banks" / "champions"
-    updater.champion_events_dir = tmp_path / "events" / "champions"
+    processor = m_champion_processor.ChampionBinProcessor.__new__(m_champion_processor.ChampionBinProcessor)
+    processor.ctx = SimpleNamespace(config=SimpleNamespace(game_path=tmp_path, dev_mode=False), paths=SimpleNamespace())
+    processor.force_update = False
+    processor.process_events = False
+    processor.version = "16.3"
+    processor.game_path = tmp_path
+    processor.champion_banks_dir = tmp_path / "banks" / "champions"
+    processor.champion_events_dir = tmp_path / "events" / "champions"
+    processor.bin_source = SimpleNamespace(_extract_bin_raws=lambda *args, **kwargs: [None, b"fallback"])
 
-    monkeypatch.setattr(m_bin_updater, "needs_update", lambda *args, **kwargs: True)
-    monkeypatch.setattr(updater, "_extract_bin_raws", lambda *args, **kwargs: [None, b"fallback"])
+    monkeypatch.setattr(m_champion_processor, "needs_update", lambda *args, **kwargs: True)
 
     write_calls = []
-    monkeypatch.setattr(m_bin_updater, "write_data", lambda *args, **kwargs: write_calls.append(True))
+    monkeypatch.setattr(m_champion_processor, "write_data", lambda *args, **kwargs: write_calls.append(True))
 
     champion_data = {
         "alias": "Annie",
@@ -217,18 +221,18 @@ def test_process_champion_skins_skips_when_first_bin_missing(tmp_path, monkeypat
         "wad": {"root": "Game/DATA/FINAL/Champions/Annie.wad.client"},
     }
 
-    updater._process_champion_skins(champion_data, "1")
+    processor._process_champion_skins(champion_data, "1")
 
     assert write_calls == []
 
 
 def test_load_map_bin_file_reads_local_bin_when_available(tmp_path, monkeypatch):
     """验证地图 BIN 可用时优先读取本地文件内容。"""
-    updater = _build_updater(tmp_path)
-    updater.game_path = tmp_path
-    updater.use_local_bin_flag_file.write_text("", encoding="utf-8")
+    source = _build_bin_source(tmp_path)
+    source.game_path = tmp_path
+    source.use_local_bin_flag_file.write_text("", encoding="utf-8")
 
-    local_file = updater.local_bin_input_dir / "data/maps/shipping/map11/map11.bin"
+    local_file = source.local_bin_input_dir / "data/maps/shipping/map11/map11.bin"
     local_file.parent.mkdir(parents=True, exist_ok=True)
     local_file.write_bytes(b"map-bin")
 
@@ -236,9 +240,9 @@ def test_load_map_bin_file_reads_local_bin_when_available(tmp_path, monkeypatch)
         def __init__(self, raw):
             self.raw = raw
 
-    monkeypatch.setattr(m_bin_updater, "BIN", FakeBIN)
+    monkeypatch.setattr(m_bin_source, "BIN", FakeBIN)
 
-    result = updater._load_map_bin_file(
+    result = source._load_map_bin_file(
         "11",
         {
             "binPath": "data/maps/shipping/map11/map11.bin",
@@ -258,14 +262,15 @@ def test_update_records_note_when_targeted_maps_exclude_common_map(tmp_path, mon
     updater.process_events = True
     updater.version = "16.3"
     updater.data_file_base = tmp_path / "data"
-    updater.use_local_bin_flag_file = tmp_path / ".use_local_bin"
+    updater.languages = []
+    updater.bin_source = SimpleNamespace(languages=[], _is_local_bin_mode_enabled=lambda: False)
+    updater._map_processor = SimpleNamespace(languages=[], _update_maps=lambda data: data)
 
     monkeypatch.setattr(
         m_bin_updater,
         "read_data",
         lambda *args, **kwargs: {"metadata": {"languages": ["zh_CN"]}, "maps": {"33": {"id": 33}}},
     )
-    monkeypatch.setattr(updater, "_update_maps", lambda data: data)
 
     updater.update(target="map", map_ids=["33"])
 
@@ -282,6 +287,9 @@ def test_update_logs_stage_start_and_summary_for_targeted_mode(tmp_path, monkeyp
     updater.version = "16.3"
     updater.data_file_base = tmp_path / "data"
     updater.languages = []
+    updater.bin_source = SimpleNamespace(languages=[], _is_local_bin_mode_enabled=lambda: True)
+    updater._champion_processor = SimpleNamespace(_update_champions=lambda _data: None)
+    updater._map_processor = SimpleNamespace(languages=[], _update_maps=lambda _data: None)
 
     info_messages: list[str] = []
     success_messages: list[str] = []
@@ -303,10 +311,7 @@ def test_update_logs_stage_start_and_summary_for_targeted_mode(tmp_path, monkeyp
             success=lambda message: success_messages.append(str(message)),
         ),
     )
-    monkeypatch.setattr(updater, "_is_local_bin_mode_enabled", lambda: True)
-    monkeypatch.setattr(updater, "_update_champions", lambda _data: None)
     monkeypatch.setattr(updater, "_record_map_event_scope_note", lambda _map_ids: None)
-    monkeypatch.setattr(updater, "_update_maps", lambda _data: None)
 
     updater.update(target="all", champion_ids=["1"], map_ids=["11"])
 
@@ -316,19 +321,18 @@ def test_update_logs_stage_start_and_summary_for_targeted_mode(tmp_path, monkeyp
 
 def test_process_single_map_records_note_when_common_dedup_removes_all_events(tmp_path, monkeypatch):
     """验证公共事件去重清空结果时会记录可解释差异。"""
-    updater = m_bin_updater.BinUpdater.__new__(m_bin_updater.BinUpdater)
-    updater.ctx = SimpleNamespace(
+    processor = m_map_processor.MapBinProcessor.__new__(m_map_processor.MapBinProcessor)
+    processor.ctx = SimpleNamespace(
         config=SimpleNamespace(game_path=tmp_path, dev_mode=False),
         runtime_cache={},
         paths=SimpleNamespace(),
     )
-    updater.force_update = False
-    updater.process_events = True
-    updater.version = "16.3"
-    updater.game_path = tmp_path
-    updater.languages = []
-    updater.map_banks_dir = tmp_path / "banks" / "maps"
-    updater.map_events_dir = tmp_path / "events" / "maps"
+    processor.force_update = False
+    processor.process_events = True
+    processor.version = "16.3"
+    processor.languages = []
+    processor.map_banks_dir = tmp_path / "banks" / "maps"
+    processor.map_events_dir = tmp_path / "events" / "maps"
 
     fake_bin = SimpleNamespace(
         theme_music=None,
@@ -346,11 +350,12 @@ def test_process_single_map_records_note_when_common_dedup_removes_all_events(tm
         ],
     )
 
-    monkeypatch.setattr(m_bin_updater, "needs_update", lambda *args, **kwargs: True)
-    monkeypatch.setattr(m_bin_updater, "write_data", lambda *args, **kwargs: None)
-    monkeypatch.setattr(updater, "_load_map_bin_file", lambda *_args, **_kwargs: fake_bin)
+    processor.bin_source = SimpleNamespace(_load_map_bin_file=lambda *_args, **_kwargs: fake_bin)
 
-    updater._process_single_map(
+    monkeypatch.setattr(m_map_processor, "needs_update", lambda *args, **kwargs: True)
+    monkeypatch.setattr(m_map_processor, "write_data", lambda *args, **kwargs: None)
+
+    processor._process_single_map(
         "33",
         {
             "binPath": "data/maps/shipping/map33/map33.bin",
@@ -360,7 +365,7 @@ def test_process_single_map_records_note_when_common_dedup_removes_all_events(tm
         set(),
     )
 
-    summary = get_or_create_run_summary(updater.ctx.runtime_cache)
+    summary = get_or_create_run_summary(processor.ctx.runtime_cache)
     assert any(
         "地图 33 (Map33) 的事件在与 地图 0 的公共事件去重后为空" in note for note in summary.stages["update"].notes
     )
@@ -369,20 +374,20 @@ def test_process_single_map_records_note_when_common_dedup_removes_all_events(tm
 
 def test_update_champions_logs_simple_progress_messages(tmp_path, monkeypatch):
     """验证英雄批量更新会输出简单的日志进度提示。"""
-    updater = m_bin_updater.BinUpdater.__new__(m_bin_updater.BinUpdater)
-    updater.ctx = SimpleNamespace(
+    processor = m_champion_processor.ChampionBinProcessor.__new__(m_champion_processor.ChampionBinProcessor)
+    processor.ctx = SimpleNamespace(
         config=SimpleNamespace(game_path=tmp_path, dev_mode=False),
         runtime_cache={},
         paths=SimpleNamespace(),
     )
-    updater.champion_banks_dir = tmp_path / "banks" / "champions"
-    updater.champion_events_dir = tmp_path / "events" / "champions"
+    processor.champion_banks_dir = tmp_path / "banks" / "champions"
+    processor.champion_events_dir = tmp_path / "events" / "champions"
     processed_ids: list[str] = []
     info_messages: list[str] = []
     success_messages: list[str] = []
 
     monkeypatch.setattr(
-        m_bin_updater,
+        m_champion_processor,
         "logger",
         SimpleNamespace(
             info=lambda message: info_messages.append(str(message)),
@@ -390,12 +395,12 @@ def test_update_champions_logs_simple_progress_messages(tmp_path, monkeypatch):
         ),
     )
     monkeypatch.setattr(
-        updater,
+        processor,
         "_process_champion_skins",
         lambda _champion_data, champion_id: processed_ids.append(champion_id),
     )
 
-    updater._update_champions({"champions": {"2": {}, "1": {}}})
+    processor._update_champions({"champions": {"2": {}, "1": {}}})
 
     assert processed_ids == ["1", "2"]
     assert "处理英雄进度 1/2: 1" in info_messages
@@ -405,20 +410,20 @@ def test_update_champions_logs_simple_progress_messages(tmp_path, monkeypatch):
 
 def test_update_maps_logs_simple_progress_messages(tmp_path, monkeypatch):
     """验证地图批量更新会输出简单的日志进度提示。"""
-    updater = m_bin_updater.BinUpdater.__new__(m_bin_updater.BinUpdater)
-    updater.ctx = SimpleNamespace(
+    processor = m_map_processor.MapBinProcessor.__new__(m_map_processor.MapBinProcessor)
+    processor.ctx = SimpleNamespace(
         config=SimpleNamespace(game_path=tmp_path, dev_mode=False),
         runtime_cache={},
         paths=SimpleNamespace(),
     )
-    updater.map_banks_dir = tmp_path / "banks" / "maps"
-    updater.map_events_dir = tmp_path / "events" / "maps"
+    processor.map_banks_dir = tmp_path / "banks" / "maps"
+    processor.map_events_dir = tmp_path / "events" / "maps"
     processed_ids: list[str] = []
     info_messages: list[str] = []
     success_messages: list[str] = []
 
     monkeypatch.setattr(
-        m_bin_updater,
+        m_map_processor,
         "logger",
         SimpleNamespace(
             info=lambda message: info_messages.append(str(message)),
@@ -428,12 +433,12 @@ def test_update_maps_logs_simple_progress_messages(tmp_path, monkeypatch):
         ),
     )
     monkeypatch.setattr(
-        updater,
+        processor,
         "_process_single_map",
         lambda map_id, *_args: processed_ids.append(map_id),
     )
 
-    updater._update_maps({"maps": {"11": {"name": "Map11"}, "12": {"name": "Map12"}}})
+    processor._update_maps({"maps": {"11": {"name": "Map11"}, "12": {"name": "Map12"}}})
 
     assert processed_ids == ["11", "12"]
     assert "处理地图进度 1/2: 11" in info_messages

--- a/tests/runtime/test_remote_preparer.py
+++ b/tests/runtime/test_remote_preparer.py
@@ -9,6 +9,7 @@ from loguru import logger
 from riotmanifest import DownloadError
 
 import lol_audio_unpack.app.facade as m_facade
+import lol_audio_unpack.app.remote_workflow as m_remote_workflow
 import lol_audio_unpack.runtime.remote.preparer as m_remote
 from lol_audio_unpack.app import create_app_context
 from lol_audio_unpack.app.facade import LolAudioUnpackApp
@@ -873,7 +874,7 @@ def test_facade_run_workflow_logs_completion_summary(
     app.extract = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
     app.cleanup_remote_artifacts = lambda: None  # type: ignore[method-assign]
     monkeypatch.setattr(
-        m_facade,
+        m_remote_workflow,
         "logger",
         SimpleNamespace(
             info=lambda message, *args: info_messages.append(_format_log(message, *args)),


### PR DESCRIPTION
## Summary
- 抽出 `RemoteWorkflowOrchestrator`，让 facade 回到标准操作编排边界。
- 拆分 `BinUpdater` 的数据来源、英雄处理器与地图处理器，降低 god class 复杂度。
- 增加远端 CLI smoke，使用 `remote_snapshot` 从 Riot live 资源验证最小 CLI 成功路径。

## Scope Note
- 已先将本地 `v3-test` 快进推送到远端；当前 PR 相对最新 `v3-test` 只包含 3 个提交、9 个文件变更。
- 新增测试只覆盖本仓库 CLI/remote_snapshot 编排，不重复 `league-tools` 中 WAD/BNK/WPK 解析层测试。

## Test Plan
- `uv run ruff check`：通过。
- `uv run pytest -q -m "not remote_live and not local_game"`：586 passed, 12 deselected。
- `uv run pytest -q -m local_game tests/test_integration_pipeline_local_game.py`：4 passed。
- `uv run pytest -q -m remote_live tests/cli/test_cli_remote_smoke.py`：1 passed。

## Risk
- 主要风险在 remote_snapshot 路径和 BinUpdater 拆分后的行为保持；已用本地客户端 pipeline 与远端 CLI smoke 覆盖基础链路。
- `remote_live` smoke 依赖 Riot live/CDN 网络状态，适合显式门禁或发版前运行，不纳入默认 pytest。
